### PR TITLE
ci(release): add publish toggle to workflow_dispatch (default upload-only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         description: "Release notes (optional)"
         required: false
         type: string
+      publish:
+        description: "Publish to Chrome Web Store (false = upload only; publish manually in the dashboard)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -100,3 +105,5 @@ jobs:
           client-id: ${{ secrets.CLIENT_ID }}
           client-secret: ${{ secrets.CLIENT_SECRET }}
           refresh-token: ${{ secrets.REFRESH_TOKEN }}
+          # 既定はアップロードのみ。実行時に publish=true を選んだときだけ公開申請する。
+          publish: ${{ inputs.publish }}


### PR DESCRIPTION
## 概要

リリースワークフロー（`workflow_dispatch`）に boolean 入力 `publish` を追加し、Chrome Web Store アップロードの公開挙動を実行時に選べるようにする。

## 変更点

- `workflow_dispatch.inputs.publish`（boolean, **既定 `false`**）を追加
- `mnao305/chrome-extension-upload` に `publish: ${{ inputs.publish }}` を渡す

## 挙動

- 既定（`publish=false`）: **アップロードのみ**。公開は Web Store ダッシュボードで手動。
- `publish=true` を選んだ実行時のみ: アップロード後に**公開申請（審査提出）**。

これまではアクションの既定 `publish=true` により手動実行＝即公開申請だったため、誤公開を防ぐ安全側のデフォルトに変更する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)