### PR TITLE
fix(extension): render player control buttons with react-icons

### DIFF
--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -12,6 +12,7 @@ import { PartyWebSocketClient } from "@/infrastructure/ws/PartyWebSocketClient";
 import { getParam } from "../dom/utils";
 import { PlayerControllerDom } from "./PlayerControllerDom";
 import { mountSidebar } from "./react/mountSidebar";
+import { mountPlayerControls } from "./react/PlayerControls";
 import type { SidebarTab } from "./react/sidebarStore";
 import { ReactionViewReact } from "./ReactionViewReact";
 
@@ -261,29 +262,13 @@ function bindReaction(
 }
 
 function addControlButtons(): void {
-  $(".space").before(
-    "<div class='sync_button controll_button'><i class='fas fa-sync-alt buttonArea_icon'></i></div>",
-  );
-  $(".space").before(
-    "<div class='thumbs_button controll_button'><i class='fas fa-thumbs-up buttonArea_icon reaction_icon'></i></div>",
-  );
-  $(".space").before(
-    "<div class='fav_button controll_button'><i class='fas fa-heart buttonArea_icon reaction_icon'></i></div>",
-  );
-  $(".space").before(
-    "<div class='smile_button controll_button'><i class='fas fa-smile-beam buttonArea_icon reaction_icon'></i></div>",
-  );
-  $(".space").before(
-    "<div class='cry_button controll_button'><i class='fas fa-sad-cry buttonArea_icon reaction_icon'></i></div>",
-  );
-  $(".space").before(
-    "<div class='middle_finger_button controll_button'><i class='fas fa-hand-middle-finger buttonArea_icon reaction_icon'></i></div>",
-  );
-  if (currentSettings.hideReactionIcon) {
-    $(".reaction_icon").hide();
-  } else {
-    $(".reaction_icon").show();
-  }
+  const space = document.getElementsByClassName("space")[0];
+  if (!space) return;
+  mountPlayerControls({
+    anchor: space,
+    initialSettings: currentSettings,
+    subscribe: (cb) => settingsRepo.onChange(cb),
+  });
 }
 
 function nextPageAnotherTab(): void {

--- a/src/presentation/content/party/react/PlayerControls.tsx
+++ b/src/presentation/content/party/react/PlayerControls.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  FaHandMiddleFinger,
+  FaHeart,
+  FaSadCry,
+  FaSmileBeam,
+  FaSyncAlt,
+  FaThumbsUp,
+} from "react-icons/fa";
+
+import type { Settings } from "@/domain/settings";
+
+type SettingsSubscribe = (cb: (s: Settings) => void) => () => void;
+
+/**
+ * Mounts the player control buttons (sync + 5 reactions) before the given
+ * anchor element. Class names match the legacy injection so existing onclick
+ * wiring in `bindPlayerEvents` keeps working.
+ */
+export function mountPlayerControls(opts: {
+  anchor: Element;
+  initialSettings: Settings;
+  subscribe: SettingsSubscribe;
+}): void {
+  const parent = opts.anchor.parentElement;
+  if (!parent) return;
+  if (document.getElementById("d-party-player-controls")) return;
+  const host = document.createElement("div");
+  host.id = "d-party-player-controls";
+  host.style.display = "contents";
+  parent.insertBefore(host, opts.anchor);
+  createRoot(host).render(
+    <PlayerControls
+      subscribe={opts.subscribe}
+      initialSettings={opts.initialSettings}
+    />,
+  );
+}
+
+/**
+ * React replacement for the legacy `addControlButtons` jQuery+FontAwesome
+ * injection. FA is no longer bundled with the extension, so the icon `<i>`
+ * tags rendered nothing — buttons appeared empty on the player. Here we
+ * render `react-icons/fa` SVGs instead. Class names (`sync_button`,
+ * `fav_button`, etc.) are preserved so existing onclick wiring in
+ * `bindPlayerEvents` keeps working unchanged.
+ */
+export function PlayerControls({
+  subscribe,
+  initialSettings,
+}: {
+  subscribe: SettingsSubscribe;
+  initialSettings: Settings;
+}) {
+  const [hidden, setHidden] = useState(initialSettings.hideReactionIcon);
+
+  useEffect(() => {
+    const off = subscribe((s) => setHidden(s.hideReactionIcon));
+    return () => off();
+  }, [subscribe]);
+
+  const reactionStyle = hidden ? { display: "none" as const } : undefined;
+
+  return (
+    <>
+      <ControlButton className="sync_button controll_button">
+        <FaSyncAlt className="buttonArea_icon" />
+      </ControlButton>
+      <ControlButton
+        className="thumbs_button controll_button"
+        style={reactionStyle}
+      >
+        <FaThumbsUp className="buttonArea_icon reaction_icon" />
+      </ControlButton>
+      <ControlButton
+        className="fav_button controll_button"
+        style={reactionStyle}
+      >
+        <FaHeart className="buttonArea_icon reaction_icon" />
+      </ControlButton>
+      <ControlButton
+        className="smile_button controll_button"
+        style={reactionStyle}
+      >
+        <FaSmileBeam className="buttonArea_icon reaction_icon" />
+      </ControlButton>
+      <ControlButton
+        className="cry_button controll_button"
+        style={reactionStyle}
+      >
+        <FaSadCry className="buttonArea_icon reaction_icon" />
+      </ControlButton>
+      <ControlButton
+        className="middle_finger_button controll_button"
+        style={reactionStyle}
+      >
+        <FaHandMiddleFinger className="buttonArea_icon reaction_icon" />
+      </ControlButton>
+    </>
+  );
+}
+
+function ControlButton({
+  className,
+  style,
+  children,
+}: {
+  className: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={className} style={style} role="button">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## 背景

Chrome 拡張の rebuild 時に Font Awesome が同梱から外れたため、`addControlButtons` が挿入していた `<i class='fas fa-*'>` 要素はグリフ無しで空のまま描画され、プレイヤーに **コントロールボタン（同期 + リアクション 5 種）が表示されない** 状態でした。

## 修正

- `react/PlayerControls.tsx` を追加し、6 つのボタン（`sync_button` / `thumbs_button` / `fav_button` / `smile_button` / `cry_button` / `middle_finger_button`）を **`react-icons/fa` の SVG** でレンダリング（追加 dep なし、既存 `react-icons@^5.4.0` を利用）。
- `mountPlayerControls()` ヘルパーが `.space` の前に React root をマウント。`display: contents` でレイアウトはレガシー DOM と等価。
- `index.ts` の `addControlButtons` を React マウントへ差し替え。**クラス名は維持**（`bindPlayerEvents` の `bindClass(...)` onclick 結線が変更なしで動く）。
- 設定 `hideReactionIcon` は `chrome.storage` の onChange を購読して、リアクション側ボタンのみ表示／非表示をリアクティブに切替。
- `idempotent`: 二重 mount を防止（`#d-party-player-controls` host を再利用）。

## 動作確認

- `pnpm typecheck` / `pnpm lint` / `pnpm build` 通過
- UI 結合の最終確認は dアニメストア有料ページの実機で要

🤖 Generated with [Claude Code](https://claude.com/claude-code)