### PR TITLE
fix(extension): wire reaction/sync button onClick via React props

### DIFF
--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -181,9 +181,7 @@ function bindPlayerEvents(): void {
   bindClick("prevThumbinner", () => {
     if (active()) session.sendVideoOperation("prev_thumbnail");
   });
-  bindClass("sync_button", () => {
-    if (active()) session.requestSync();
-  });
+  // sync_button / *_button (reactions) は React コンポーネント側で onClick を結線済み。
 
   bindClass("backArea", () => {
     if (session.inRoom && guard.available) {
@@ -215,12 +213,6 @@ function bindPlayerEvents(): void {
     };
   });
 
-  bindReaction("fav_button", "fav");
-  bindReaction("middle_finger_button", "middle_finger");
-  bindReaction("thumbs_button", "thumbs_up");
-  bindReaction("smile_button", "smile");
-  bindReaction("cry_button", "cry");
-
   window.addEventListener("keydown", (event) => {
     const playKeys = ["Space", "Enter", "NumpadEnter", "KeyK"];
     const skipKeys = [
@@ -249,18 +241,6 @@ function bindClass(cls: string, handler: () => void): void {
   if (el) el.onclick = handler;
 }
 
-function bindReaction(
-  buttonClass: string,
-  type: "fav" | "middle_finger" | "thumbs_up" | "smile" | "cry",
-): void {
-  bindClass(buttonClass, () => {
-    if (session.inRoom) {
-      reactions.play(type);
-      session.sendReaction(type);
-    }
-  });
-}
-
 function addControlButtons(): void {
   const space = document.getElementsByClassName("space")[0];
   if (!space) return;
@@ -268,6 +248,16 @@ function addControlButtons(): void {
     anchor: space,
     initialSettings: currentSettings,
     subscribe: (cb) => settingsRepo.onChange(cb),
+    handlers: {
+      onSync: () => {
+        if (guard.available && session.inRoom) session.requestSync();
+      },
+      onReaction: (type) => {
+        if (!session.inRoom) return;
+        reactions.play(type);
+        session.sendReaction(type);
+      },
+    },
   });
 }
 

--- a/src/presentation/content/party/react/PlayerControls.tsx
+++ b/src/presentation/content/party/react/PlayerControls.tsx
@@ -9,19 +9,27 @@ import {
   FaThumbsUp,
 } from "react-icons/fa";
 
+import type { ReactionType } from "@/domain/reactions";
 import type { Settings } from "@/domain/settings";
 
 type SettingsSubscribe = (cb: (s: Settings) => void) => () => void;
 
+export interface PlayerControlsHandlers {
+  onSync: () => void;
+  onReaction: (type: ReactionType) => void;
+}
+
 /**
  * Mounts the player control buttons (sync + 5 reactions) before the given
- * anchor element. Class names match the legacy injection so existing onclick
- * wiring in `bindPlayerEvents` keeps working.
+ * anchor element. Handlers are wired via React props so they take effect
+ * regardless of when React commits (the legacy `getElementsByClassName`
+ * approach raced with React's async render).
  */
 export function mountPlayerControls(opts: {
   anchor: Element;
   initialSettings: Settings;
   subscribe: SettingsSubscribe;
+  handlers: PlayerControlsHandlers;
 }): void {
   const parent = opts.anchor.parentElement;
   if (!parent) return;
@@ -34,24 +42,25 @@ export function mountPlayerControls(opts: {
     <PlayerControls
       subscribe={opts.subscribe}
       initialSettings={opts.initialSettings}
+      handlers={opts.handlers}
     />,
   );
 }
 
 /**
  * React replacement for the legacy `addControlButtons` jQuery+FontAwesome
- * injection. FA is no longer bundled with the extension, so the icon `<i>`
- * tags rendered nothing — buttons appeared empty on the player. Here we
- * render `react-icons/fa` SVGs instead. Class names (`sync_button`,
- * `fav_button`, etc.) are preserved so existing onclick wiring in
- * `bindPlayerEvents` keeps working unchanged.
+ * injection. Renders sync + 5 reaction buttons as `react-icons/fa` SVGs.
+ * Class names (`sync_button`, `fav_button`, ...) are kept for CSS parity
+ * with the original player.css.
  */
 export function PlayerControls({
   subscribe,
   initialSettings,
+  handlers,
 }: {
   subscribe: SettingsSubscribe;
   initialSettings: Settings;
+  handlers: PlayerControlsHandlers;
 }) {
   const [hidden, setHidden] = useState(initialSettings.hideReactionIcon);
 
@@ -64,36 +73,44 @@ export function PlayerControls({
 
   return (
     <>
-      <ControlButton className="sync_button controll_button">
+      <ControlButton
+        className="sync_button controll_button"
+        onClick={handlers.onSync}
+      >
         <FaSyncAlt className="buttonArea_icon" />
       </ControlButton>
       <ControlButton
         className="thumbs_button controll_button"
         style={reactionStyle}
+        onClick={() => handlers.onReaction("thumbs_up")}
       >
         <FaThumbsUp className="buttonArea_icon reaction_icon" />
       </ControlButton>
       <ControlButton
         className="fav_button controll_button"
         style={reactionStyle}
+        onClick={() => handlers.onReaction("fav")}
       >
         <FaHeart className="buttonArea_icon reaction_icon" />
       </ControlButton>
       <ControlButton
         className="smile_button controll_button"
         style={reactionStyle}
+        onClick={() => handlers.onReaction("smile")}
       >
         <FaSmileBeam className="buttonArea_icon reaction_icon" />
       </ControlButton>
       <ControlButton
         className="cry_button controll_button"
         style={reactionStyle}
+        onClick={() => handlers.onReaction("cry")}
       >
         <FaSadCry className="buttonArea_icon reaction_icon" />
       </ControlButton>
       <ControlButton
         className="middle_finger_button controll_button"
         style={reactionStyle}
+        onClick={() => handlers.onReaction("middle_finger")}
       >
         <FaHandMiddleFinger className="buttonArea_icon reaction_icon" />
       </ControlButton>
@@ -104,14 +121,16 @@ export function PlayerControls({
 function ControlButton({
   className,
   style,
+  onClick,
   children,
 }: {
   className: string;
   style?: React.CSSProperties;
+  onClick?: () => void;
   children: React.ReactNode;
 }) {
   return (
-    <div className={className} style={style} role="button">
+    <div className={className} style={style} role="button" onClick={onClick}>
       {children}
     </div>
   );


### PR DESCRIPTION
## 症状

PR #7 でコントロールボタンは表示されるようになったが、**リアクションボタンを押してもオーバーレイが出ない**。

## 原因

`createRoot().render()` は React 18+ で**非同期コミット**。`addControlButtons()` 直後に呼ばれる `bindPlayerEvents()` 内の `bindClass(\"fav_button\", ...)`（= `getElementsByClassName` で onclick を貼る）が **React の描画前**に走り、対象要素がまだ存在しないため onclick が登録されていなかった。同様に `sync_button` も無反応だったはず。

## 修正

ハンドラを React コンポーネントの **props** として渡し、`onClick` を React 側で結線する（描画タイミングに依存しない）。

- `PlayerControls` に `handlers: { onSync, onReaction }` prop を追加
- `mountPlayerControls` に `handlers` を受け取らせる
- `index.ts` の `bindReaction × 5` と `bindClass(\"sync_button\", ...)` を撤去し、`mountPlayerControls` 呼び出し時に handlers を渡す
- 発火条件はレガシーと同等: リアクションは `session.inRoom`、sync は `guard.available && session.inRoom`

## 動作確認

- `pnpm typecheck` / `pnpm lint` / `pnpm build` 通過
- 実機（dアニメストア）で要最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)