### PR TITLE
feat: send anime title when creating a room

### DIFF
--- a/src/application/RoomSession.ts
+++ b/src/application/RoomSession.ts
@@ -69,7 +69,7 @@ export class RoomSession {
   // -- connection lifecycle --------------------------------------------------
 
   /** Host a new room for the given part. */
-  createRoom(partId: string): void {
+  createRoom(partId: string, title = ""): void {
     this._inRoom = true;
     this.joined = false;
     this.resetDelayMs = 100;
@@ -79,6 +79,7 @@ export class RoomSession {
         action: "create",
         user_name: this.userName,
         part_id: partId,
+        title,
         request_id: now(),
       });
     });

--- a/src/domain/protocol.ts
+++ b/src/domain/protocol.ts
@@ -44,6 +44,11 @@ export interface CreateRoomMessage {
   action: "create";
   user_name: string;
   part_id: string;
+  /**
+   * 視聴中アニメのタイトル（ページ DOM から取得）。OGP 表示用にルーム作成時に
+   * 一度だけ送る。バックエンドは未指定でも受理する（旧バージョン互換）。
+   */
+  title: string;
   request_id: number;
 }
 

--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -49,7 +49,9 @@ const { store: sidebarStore, controller: sidebarController } = mountSidebar({
   onCreateRoom: () => {
     addControlButtons();
     bindPlayerEvents();
-    session.createRoom(getParam("partId") ?? "");
+    // 視聴中アニメのタイトルをページ DOM から取得してルーム作成時に一度だけ送る
+    // （OGP 表示用）。取得できない場合は空文字で、バックエンドは未指定でも受理する。
+    session.createRoom(getParam("partId") ?? "", shareTitle());
   },
   onLeave: () => {
     if (!session.inRoom) return;


### PR DESCRIPTION
## What
Send the currently-playing anime title to the backend when a room is created, so room links can show rich OGP cards (backend: d-party/backend#169, frontend: d-party/frontend).

## Changes
- `createRoom(partId, title)` includes `title` in the `create` WebSocket message
- `CreateRoomMessage` protocol type gains `title`
- The title is read from the player page DOM via the existing `shareTitle()` (`backInfoTxt1`-`3`), so no new DOM coupling

## Notes
- Sent **once** at room creation (no updates on episode change).
- Additive/optional on the server; older backends ignore the extra field, so this is backward compatible.

`pnpm typecheck` / `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)