### PR TITLE
feat: プレイヤーにピクチャーインピクチャー機能を追加

### DIFF
--- a/public/css/player.css
+++ b/public/css/player.css
@@ -249,6 +249,28 @@
   color: #6380ad;
 }
 
+/* PiP ボタン: dアニメストアのコントロールバー（最大化ボタンの左）に並べる。
+   ネイティブの .mainButton button（44x50, opacity .6, hover で 1）に合わせる。 */
+.pip_main_button {
+  width: 44px;
+  height: 50px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: top;
+  cursor: pointer;
+}
+.pip_main_button svg {
+  width: 26px;
+  height: 26px;
+  color: #fff;
+  opacity: 0.6;
+  transition: opacity 0.1s;
+}
+.pip_main_button:hover svg {
+  opacity: 1;
+}
+
 .sync_button:hover {
   animation: r1 1.5s linear infinite;
 }

--- a/src/domain/settings.ts
+++ b/src/domain/settings.ts
@@ -7,6 +7,7 @@
 export interface Settings {
   autoAnotherTab: boolean;
   autoUserNameDecision: boolean;
+  enablePictureInPicture: boolean;
   hideReaction: boolean;
   hideReactionIcon: boolean;
   selfNotification: boolean;
@@ -16,6 +17,7 @@ export interface Settings {
 export const DEFAULT_SETTINGS: Settings = {
   autoAnotherTab: true,
   autoUserNameDecision: false,
+  enablePictureInPicture: true,
   hideReaction: false,
   hideReactionIcon: false,
   selfNotification: false,
@@ -26,6 +28,7 @@ export const DEFAULT_SETTINGS: Settings = {
 export const STORAGE_KEYS = {
   autoAnotherTab: "auto_another_tab",
   autoUserNameDecision: "auto_user_name_decision",
+  enablePictureInPicture: "enable_picture_in_picture",
   hideReaction: "hide_reaction",
   hideReactionIcon: "hide_reaction_icon",
   selfNotification: "self_notification",

--- a/src/infrastructure/storage/ChromeStorageSettingsRepository.ts
+++ b/src/infrastructure/storage/ChromeStorageSettingsRepository.ts
@@ -14,6 +14,7 @@ export class ChromeStorageSettingsRepository {
     return {
       autoAnotherTab: bool(stored[STORAGE_KEYS.autoAnotherTab], DEFAULT_SETTINGS.autoAnotherTab),
       autoUserNameDecision: bool(stored[STORAGE_KEYS.autoUserNameDecision], DEFAULT_SETTINGS.autoUserNameDecision),
+      enablePictureInPicture: bool(stored[STORAGE_KEYS.enablePictureInPicture], DEFAULT_SETTINGS.enablePictureInPicture),
       hideReaction: bool(stored[STORAGE_KEYS.hideReaction], DEFAULT_SETTINGS.hideReaction),
       hideReactionIcon: bool(stored[STORAGE_KEYS.hideReactionIcon], DEFAULT_SETTINGS.hideReactionIcon),
       selfNotification: bool(stored[STORAGE_KEYS.selfNotification], DEFAULT_SETTINGS.selfNotification),

--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -12,6 +12,7 @@ import { PartyWebSocketClient } from "@/infrastructure/ws/PartyWebSocketClient";
 import { getParam } from "../dom/utils";
 import { PlayerControllerDom } from "./PlayerControllerDom";
 import { mountSidebar } from "./react/mountSidebar";
+import { mountPipButton } from "./react/PipButton";
 import { mountPlayerControls } from "./react/PlayerControls";
 import type { SidebarTab } from "./react/sidebarStore";
 import { ReactionViewReact } from "./ReactionViewReact";
@@ -87,6 +88,11 @@ window.addEventListener("load", () => {
   if (mode !== "normal") video().removeAttribute("autoplay");
   nextPageAnotherTab();
 });
+
+// The PiP button is room-independent: mount it on every player page as soon as
+// dアニメストア builds its control bar (the native player JS injects it after
+// the video initializes, so we wait for the fullscreen button to appear).
+mountPipControl();
 
 // Hide the sidebar in fullscreen. The React toast viewport mounts to its own
 // Shadow DOM host and doesn't need repositioning.
@@ -261,6 +267,69 @@ function addControlButtons(): void {
       },
     },
   });
+}
+
+/**
+ * Toggle native Picture-in-Picture for the player video. Local-only: PiP is a
+ * per-viewer preference and is not propagated over the room WebSocket.
+ */
+async function togglePictureInPicture(): Promise<void> {
+  const v = video();
+  if (!document.pictureInPictureEnabled || v.disablePictureInPicture) {
+    notifier.alert(
+      "このブラウザ／動画ではピクチャーインピクチャーを利用できません",
+    );
+    return;
+  }
+  try {
+    if (document.pictureInPictureElement) {
+      await document.exitPictureInPicture();
+    } else {
+      await v.requestPictureInPicture();
+    }
+  } catch {
+    notifier.alert("ピクチャーインピクチャーの切り替えに失敗しました");
+  }
+}
+
+/**
+ * Mount the PiP button into the dアニメストア control bar, immediately left of
+ * the native fullscreen (最大化) button. The control bar is injected by the
+ * page's player JS after the video initializes, so we wait for the fullscreen
+ * button to appear before mounting.
+ */
+function mountPipControl(): void {
+  const mount = (fullscreenButton: Element): void => {
+    mountPipButton({
+      fullscreenButton,
+      initialSettings: currentSettings,
+      // Deliver the stored value immediately (the settings load is async and
+      // may not have resolved by mount time), then keep it live on changes.
+      subscribe: (cb) => {
+        void settingsRepo.getAll().then(cb);
+        return settingsRepo.onChange(cb);
+      },
+      onToggle: () => void togglePictureInPicture(),
+    });
+  };
+
+  // `.fullscreen` alone is also toggled on containers while in fullscreen mode,
+  // so match the control-bar button precisely as `.fullscreen.mainButton`.
+  const findButton = () => document.querySelector(".fullscreen.mainButton");
+
+  const existing = findButton();
+  if (existing) {
+    mount(existing);
+    return;
+  }
+  const observer = new MutationObserver(() => {
+    const el = findButton();
+    if (el) {
+      observer.disconnect();
+      mount(el);
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
 }
 
 function nextPageAnotherTab(): void {

--- a/src/presentation/content/party/react/PipButton.tsx
+++ b/src/presentation/content/party/react/PipButton.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { MdPictureInPicture, MdPictureInPictureAlt } from "react-icons/md";
+
+import type { Settings } from "@/domain/settings";
+
+type SettingsSubscribe = (cb: (s: Settings) => void) => () => void;
+
+/**
+ * Mounts the Picture-in-Picture toggle into the dアニメストア control bar, just
+ * before the native fullscreen (最大化) button — the rightmost `.mainButton`.
+ *
+ * Unlike the sync/reaction buttons this is room-independent: it is shown on
+ * every player page whenever the user has the feature enabled, regardless of
+ * whether (or how many) rooms they are in. PiP is a local viewing preference
+ * and is intentionally not synced over the room WebSocket.
+ */
+export function mountPipButton(opts: {
+  /** The native `.fullscreen.mainButton`; the PiP button is inserted before it. */
+  fullscreenButton: Element;
+  initialSettings: Settings;
+  subscribe: SettingsSubscribe;
+  onToggle: () => void;
+}): void {
+  const parent = opts.fullscreenButton.parentElement;
+  if (!parent) return;
+  if (document.getElementById("d-party-pip-button")) return;
+  const host = document.createElement("div");
+  host.id = "d-party-pip-button";
+  host.style.display = "contents";
+  parent.insertBefore(host, opts.fullscreenButton);
+  createRoot(host).render(
+    <PipButton
+      initialSettings={opts.initialSettings}
+      subscribe={opts.subscribe}
+      onToggle={opts.onToggle}
+    />,
+  );
+}
+
+export function PipButton({
+  initialSettings,
+  subscribe,
+  onToggle,
+}: {
+  initialSettings: Settings;
+  subscribe: SettingsSubscribe;
+  onToggle: () => void;
+}) {
+  const [enabled, setEnabled] = useState(initialSettings.enablePictureInPicture);
+  const inPip = usePipState();
+
+  useEffect(() => {
+    const off = subscribe((s) => setEnabled(s.enablePictureInPicture));
+    return () => off();
+  }, [subscribe]);
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className="pip_main_button"
+      role="button"
+      title={
+        inPip ? "ピクチャーインピクチャーを終了" : "ピクチャーインピクチャーで再生"
+      }
+      onClick={onToggle}
+    >
+      {inPip ? <MdPictureInPicture /> : <MdPictureInPictureAlt />}
+    </div>
+  );
+}
+
+/**
+ * Tracks whether the player `<video>` is currently in Picture-in-Picture so the
+ * button can swap its icon/label.
+ */
+function usePipState(): boolean {
+  const [inPip, setInPip] = useState(false);
+  useEffect(() => {
+    const v = document.getElementById("video") as HTMLVideoElement | null;
+    if (!v) return;
+    const update = () => setInPip(document.pictureInPictureElement === v);
+    v.addEventListener("enterpictureinpicture", update);
+    v.addEventListener("leavepictureinpicture", update);
+    update();
+    return () => {
+      v.removeEventListener("enterpictureinpicture", update);
+      v.removeEventListener("leavepictureinpicture", update);
+    };
+  }, []);
+  return inPip;
+}

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -1,10 +1,13 @@
 import {
   Bell,
   Check,
+  ChevronDown,
   ExternalLink,
   Eye,
   type LucideIcon,
+  MonitorPlay,
   Pencil,
+  PictureInPicture2,
   SlidersHorizontal,
   Smile,
   User,
@@ -22,7 +25,7 @@ import { useSettings } from "./useSettings";
 
 type ToggleKey = Exclude<keyof Settings, "userName">;
 
-const TOGGLES: {
+interface Toggle {
   key: ToggleKey;
   label: string;
   description: string;
@@ -33,13 +36,10 @@ const TOGGLES: {
    * (e.g. `hideReaction`). The storage keys stay backward-compatible.
    */
   invert?: boolean;
-}[] = [
-  {
-    key: "autoAnotherTab",
-    label: "別タブで自動再生",
-    description: "動画を新しいタブで開く",
-    icon: ExternalLink,
-  },
+}
+
+/** Watch-party settings: reactions and operation notifications. */
+const SYNC_TOGGLES: Toggle[] = [
   {
     key: "hideReaction",
     label: "リアクションを表示",
@@ -60,6 +60,22 @@ const TOGGLES: {
     description: "自分の再生操作を通知する",
     icon: Bell,
     invert: true,
+  },
+];
+
+/** Utility settings independent of the watch party. */
+const UTILITY_TOGGLES: Toggle[] = [
+  {
+    key: "autoAnotherTab",
+    label: "別タブで自動再生",
+    description: "動画を新しいタブで開く",
+    icon: ExternalLink,
+  },
+  {
+    key: "enablePictureInPicture",
+    label: "ピクチャーインピクチャーを有効",
+    description: "プレイヤーに PiP ボタンを表示する",
+    icon: PictureInPicture2,
   },
 ];
 
@@ -98,6 +114,27 @@ export function PopupApp(): React.JSX.Element {
     setSaved(true);
     window.setTimeout(() => setSaved(false), 1500);
   };
+
+  const renderToggle = ({ key, label, description, icon: Icon, invert }: Toggle) => (
+    <label
+      key={key}
+      htmlFor={key}
+      className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/70"
+    >
+      <span className="flex items-center gap-3">
+        <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="flex flex-col">
+          <span className="text-sm font-medium leading-tight">{label}</span>
+          <span className="text-xs text-muted-foreground">{description}</span>
+        </span>
+      </span>
+      <Switch
+        id={key}
+        checked={invert ? !settings[key] : settings[key]}
+        onCheckedChange={(checked) => void update(key, invert ? !checked : checked)}
+      />
+    </label>
+  );
 
   return (
     <div className="bg-background text-foreground">
@@ -175,42 +212,64 @@ export function PopupApp(): React.JSX.Element {
           )}
         </section>
 
-        {/* Player settings */}
-        <section className="rounded-xl border bg-card p-2 shadow-sm">
-          <div className="flex items-center gap-2 px-2 py-1.5">
-            <SlidersHorizontal className="size-4 text-red-600" aria-hidden />
-            <h2 className="text-sm font-semibold">プレイヤー設定</h2>
-          </div>
-          <div className="mt-1 space-y-0.5">
-            {TOGGLES.map(({ key, label, description, icon: Icon, invert }) => (
-              <label
-                key={key}
-                htmlFor={key}
-                className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/70"
-              >
-                <span className="flex items-center gap-3">
-                  <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-                  <span className="flex flex-col">
-                    <span className="text-sm font-medium leading-tight">{label}</span>
-                    <span className="text-xs text-muted-foreground">{description}</span>
-                  </span>
-                </span>
-                <Switch
-                  id={key}
-                  checked={invert ? !settings[key] : settings[key]}
-                  onCheckedChange={(checked) =>
-                    void update(key, invert ? !checked : checked)
-                  }
-                />
-              </label>
-            ))}
-          </div>
-        </section>
+        {/* Watch-party settings */}
+        <ToggleSection
+          title="同時視聴設定"
+          icon={MonitorPlay}
+          toggles={SYNC_TOGGLES}
+          renderToggle={renderToggle}
+        />
+
+        {/* Utility settings (kept last) */}
+        <ToggleSection
+          title="ユーティリティ設定"
+          icon={SlidersHorizontal}
+          toggles={UTILITY_TOGGLES}
+          renderToggle={renderToggle}
+        />
       </main>
 
       <footer className="px-4 pb-3 text-center text-[11px] text-muted-foreground">
         v{appVersion()} · powered by U-Not
       </footer>
     </div>
+  );
+}
+
+/**
+ * A settings section that is collapsed by default and expands on click, so the
+ * popup stays short enough to avoid scrolling until a section is opened.
+ */
+function ToggleSection({
+  title,
+  icon: Icon,
+  toggles,
+  renderToggle,
+}: {
+  title: string;
+  icon: LucideIcon;
+  toggles: Toggle[];
+  renderToggle: (toggle: Toggle) => React.JSX.Element;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <section className="rounded-xl border bg-card p-2 shadow-sm">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/70"
+      >
+        <Icon className="size-4 text-red-600" aria-hidden />
+        <h2 className="text-sm font-semibold">{title}</h2>
+        <ChevronDown
+          className={`ml-auto size-4 text-muted-foreground transition-transform ${
+            open ? "rotate-180" : ""
+          }`}
+          aria-hidden
+        />
+      </button>
+      {open && <div className="mt-1 space-y-0.5">{toggles.map(renderToggle)}</div>}
+    </section>
   );
 }

--- a/src/presentation/popup/styles.css
+++ b/src/presentation/popup/styles.css
@@ -91,5 +91,5 @@ body {
 }
 
 #root {
-  width: 340px;
+  width: 360px;
 }


### PR DESCRIPTION
## 概要

dアニメストアのプレイヤーに **ピクチャーインピクチャー（PiP）** 機能を追加しました。

## 変更点

- **PiPトグルボタン**: コントロールバーの最大化（最右）ボタンの左に常時表示。`.fullscreen.mainButton` の直前に挿入。
  - **ルーム非依存**: ルームに入っていなくても、複数の部屋に入っていても表示。
  - **local-only**: PiP は各視聴者の表示の好みなので WebSocket 同期プロトコルには一切影響しない。
  - `enter/leavepictureinpicture` を監視してアイコン・ツールチップを切替。未対応・失敗時はトースト通知でフォールバック。
- **設定追加**: 「ピクチャーインピクチャーを有効」（既定 ON, storage key `enable_picture_in_picture`）。OFF で即非表示。
- **popup 設定の再構成**:
  - 「プレイヤー設定」を **同時視聴設定** / **ユーティリティ設定** の2セクションに分割（PiP・別タブ自動再生はユーティリティとして最下部）。
  - 各セクションを**折りたたみ式**（既定は折りたたみ、クリックで展開）にしてスクロールを解消。
  - popup 幅を 340 → 360px に拡張。

## 確認

- `pnpm typecheck` / `pnpm lint` / `pnpm build` すべて通過。
- ⚠️ content script の DOM 結合は有料の dアニメストア実ページでのみ完全検証可能。PiP 可否はブラウザ/DRM コンテンツ依存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)