### PR TITLE
feat(popup): client-only personal usage stats (設定/統計 tabs)

### DIFF
--- a/src/application/RoomSession.ts
+++ b/src/application/RoomSession.ts
@@ -15,6 +15,7 @@ import type {
   ReactionView,
   SettingsProvider,
   SidebarView,
+  StatsRecorder,
 } from "./ports";
 
 export interface RoomSessionDeps {
@@ -25,6 +26,7 @@ export interface RoomSessionDeps {
   notifier: Notifier;
   settings: SettingsProvider;
   guard: ActionGuard;
+  stats: StatsRecorder;
 }
 
 const SERVER_DISCONNECTED = "サーバーとの通信が終了";
@@ -54,6 +56,13 @@ export class RoomSession {
   // 手動 sync ボタン押下に対する sync_response のときだけトーストを出すためのフラグ。
   // join 直後の自動 sync 時はトーストを抑制したいので必要。
   private pendingManualSyncToast = false;
+  // ルームに接続（create/join 確定）してから、まだ統計へ加算していない区間の
+  // 開始時刻。切断時・チェックポイント時に「now - connectedAt」を加算する。
+  private connectedAt: number | null = null;
+  // 接続中、経過時間を定期的に統計へ書き出すタイマー。タブを閉じる/落ちると
+  // 切断ハンドラが走らないことがあるため、最大でも CHECKPOINT_MS 分しか取りこぼさない。
+  private connectionCheckpointTimer: number | null = null;
+  static CONNECTION_CHECKPOINT_MS = 60000;
 
   userId = "";
   roomId = "";
@@ -124,6 +133,7 @@ export class RoomSession {
           });
         }
         this.stopHeartbeat();
+        this.endConnectionTracking();
         this.isHost = false;
         this._inRoom = false;
         this.joined = false;
@@ -131,6 +141,34 @@ export class RoomSession {
         this.deps.sidebar.setConnectionStatus("failed");
       },
     });
+  }
+
+  // create/join 確定時に接続時間の計測を開始する。
+  private startConnectionTracking(): void {
+    this.connectedAt = now();
+    if (this.connectionCheckpointTimer !== null) return;
+    this.connectionCheckpointTimer = window.setInterval(() => {
+      this.checkpointConnection();
+    }, RoomSession.CONNECTION_CHECKPOINT_MS);
+  }
+
+  // 未加算区間を統計へ書き出し、計測の起点を現在時刻へ進める（接続は継続）。
+  private checkpointConnection(): void {
+    if (this.connectedAt === null) return;
+    const at = now();
+    this.deps.stats.connectionEnded(at - this.connectedAt);
+    this.connectedAt = at;
+  }
+
+  // 切断時に残りの経過時間を加算し、計測を完全に停止する。connectedAt が null
+  // （未接続/加算済み）のときは何もしないので、leave()→onClose の二重計上を防ぐ。
+  private endConnectionTracking(): void {
+    this.checkpointConnection();
+    this.connectedAt = null;
+    if (this.connectionCheckpointTimer !== null) {
+      window.clearInterval(this.connectionCheckpointTimer);
+      this.connectionCheckpointTimer = null;
+    }
   }
 
   // -- outgoing intents (called by DOM event handlers) -----------------------
@@ -183,12 +221,14 @@ export class RoomSession {
 
   sendReaction(reactionType: ReactionType): void {
     this.send({ action: "reaction", reaction_type: reactionType, request_id: now() });
+    this.deps.stats.reactionSent(reactionType);
   }
 
   /** Leave the room (caller is responsible for any UI teardown). */
   leave(): void {
     this.send({ action: "leave", user_name: this.userName, request_id: now() });
     this.stopHeartbeat();
+    this.endConnectionTracking();
     this.isHost = false;
     this._inRoom = false;
   }
@@ -251,6 +291,8 @@ export class RoomSession {
         this.roomId = message.room_id;
         this.joined = true;
         this.isHost = true;
+        this.startConnectionTracking();
+        this.deps.stats.roomCreated();
         this.startHeartbeat();
         sidebar.setSelfUserId(this.userId);
         sidebar.setShareLink(ANIMESTORE_REDIRECT_ENDPOINT + this.roomId);
@@ -268,6 +310,8 @@ export class RoomSession {
         this.userId = message.user.user_id;
         this.roomId = message.room_id;
         this.joined = true;
+        this.startConnectionTracking();
+        this.deps.stats.roomJoined();
         sidebar.setSelfUserId(this.userId);
         sidebar.setShareLink(ANIMESTORE_REDIRECT_ENDPOINT + this.roomId);
         sidebar.setJoined(true);

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -49,3 +49,16 @@ export interface ReactionView {
 export interface SettingsProvider {
   current(): Settings;
 }
+
+/**
+ * Records personal usage statistics. Calls are fire-and-forget from the
+ * session's perspective; the implementation persists them asynchronously and
+ * independently of the backend.
+ */
+export interface StatsRecorder {
+  roomCreated(): void;
+  roomJoined(): void;
+  reactionSent(type: ReactionType): void;
+  /** Report a finished connection so its duration can be accumulated. */
+  connectionEnded(durationMs: number): void;
+}

--- a/src/domain/personalStats.ts
+++ b/src/domain/personalStats.ts
@@ -1,0 +1,78 @@
+/**
+ * Personal usage statistics, accumulated entirely on the client.
+ *
+ * These are private, per-account figures (stored in `chrome.storage.sync`, so
+ * they follow the signed-in Chrome profile) and are **independent of the
+ * backend** — nothing here is reported to or fetched from the server. They
+ * mirror, on a personal scale, the aggregate figures the frontend `/stats`
+ * dashboard shows for the whole service.
+ */
+
+import { REACTION_TYPES, type ReactionType } from "./reactions";
+
+export interface PersonalStats {
+  /** Number of rooms the user has hosted (created). */
+  roomsCreated: number;
+  /** Number of rooms the user has joined as a guest. */
+  roomsJoined: number;
+  /** Reactions the user has sent, broken down by kind. */
+  reactionsByType: Record<ReactionType, number>;
+  /** Total time spent connected to a room, in milliseconds. */
+  connectionMs: number;
+  /** Epoch ms of the first recorded activity, or null before any. */
+  since: number | null;
+}
+
+function zeroReactions(): Record<ReactionType, number> {
+  return Object.fromEntries(REACTION_TYPES.map((t) => [t, 0])) as Record<
+    ReactionType,
+    number
+  >;
+}
+
+export function emptyStats(): PersonalStats {
+  return {
+    roomsCreated: 0,
+    roomsJoined: 0,
+    reactionsByType: zeroReactions(),
+    connectionMs: 0,
+    since: null,
+  };
+}
+
+/** Total reactions sent across all kinds. */
+export function totalReactions(stats: PersonalStats): number {
+  return REACTION_TYPES.reduce(
+    (sum, t) => sum + (stats.reactionsByType[t] ?? 0),
+    0,
+  );
+}
+
+/**
+ * Coerce an unknown stored value into a valid {@link PersonalStats}, filling in
+ * any missing/invalid fields with zeros. Keeps old stored data forward-compatible.
+ */
+export function normalizeStats(value: unknown): PersonalStats {
+  const base = emptyStats();
+  if (!value || typeof value !== "object") return base;
+  const v = value as Record<string, unknown>;
+
+  const num = (x: unknown): number =>
+    typeof x === "number" && Number.isFinite(x) && x >= 0 ? x : 0;
+
+  const reactions = zeroReactions();
+  const stored = v.reactionsByType;
+  if (stored && typeof stored === "object") {
+    for (const t of REACTION_TYPES) {
+      reactions[t] = num((stored as Record<string, unknown>)[t]);
+    }
+  }
+
+  return {
+    roomsCreated: num(v.roomsCreated),
+    roomsJoined: num(v.roomsJoined),
+    reactionsByType: reactions,
+    connectionMs: num(v.connectionMs),
+    since: typeof v.since === "number" && v.since > 0 ? v.since : null,
+  };
+}

--- a/src/domain/reactions.ts
+++ b/src/domain/reactions.ts
@@ -11,3 +11,15 @@ export const REACTION_TYPES = [
 ] as const;
 
 export type ReactionType = (typeof REACTION_TYPES)[number];
+
+/** Display label and emoji for each reaction kind (used by the popup stats). */
+export const REACTION_META: Record<
+  ReactionType,
+  { label: string; emoji: string }
+> = {
+  fav: { label: "お気に入り", emoji: "❤️" },
+  thumbs_up: { label: "いいね", emoji: "👍" },
+  smile: { label: "笑顔", emoji: "😄" },
+  cry: { label: "涙", emoji: "😢" },
+  middle_finger: { label: "ブーイング", emoji: "🖕" },
+};

--- a/src/infrastructure/storage/ChromePersonalStatsRepository.ts
+++ b/src/infrastructure/storage/ChromePersonalStatsRepository.ts
@@ -1,0 +1,75 @@
+import {
+  emptyStats,
+  normalizeStats,
+  type PersonalStats,
+} from "@/domain/personalStats";
+import type { ReactionType } from "@/domain/reactions";
+
+/** `chrome.storage.sync` key holding the serialized {@link PersonalStats}. */
+const STORAGE_KEY = "personal_stats";
+
+/**
+ * Reads/writes {@link PersonalStats} from `chrome.storage.sync` as a single
+ * JSON object. Stored under the signed-in Chrome profile, so the figures are
+ * per-account and roam across the user's devices.
+ *
+ * Updates are read-modify-write. A single user driving one player tab at a
+ * time makes contention a non-issue in practice; writes are serialized through
+ * an in-process promise chain so rapid successive increments don't clobber one
+ * another within the same context.
+ */
+export class ChromePersonalStatsRepository {
+  /** Serializes mutations so back-to-back increments don't race each other. */
+  private queue: Promise<void> = Promise.resolve();
+
+  async getAll(): Promise<PersonalStats> {
+    const stored = await chrome.storage.sync.get([STORAGE_KEY]);
+    return normalizeStats(stored[STORAGE_KEY]);
+  }
+
+  /** Apply a mutation to the current stats and persist the result. */
+  private mutate(fn: (stats: PersonalStats) => void): Promise<void> {
+    this.queue = this.queue.then(async () => {
+      const stats = await this.getAll();
+      if (stats.since === null) stats.since = Date.now();
+      fn(stats);
+      await chrome.storage.sync.set({ [STORAGE_KEY]: stats });
+    });
+    // Don't let one rejected write break the chain for later mutations.
+    return this.queue.catch(() => undefined);
+  }
+
+  incrementRoomsCreated(): Promise<void> {
+    return this.mutate((s) => (s.roomsCreated += 1));
+  }
+
+  incrementRoomsJoined(): Promise<void> {
+    return this.mutate((s) => (s.roomsJoined += 1));
+  }
+
+  incrementReaction(type: ReactionType): Promise<void> {
+    return this.mutate((s) => (s.reactionsByType[type] += 1));
+  }
+
+  addConnectionMs(ms: number): Promise<void> {
+    if (!(ms > 0)) return Promise.resolve();
+    return this.mutate((s) => (s.connectionMs += Math.round(ms)));
+  }
+
+  /** Clear all accumulated statistics back to zero. */
+  async reset(): Promise<void> {
+    this.queue = this.queue.then(() =>
+      chrome.storage.sync.set({ [STORAGE_KEY]: emptyStats() }),
+    );
+    return this.queue.catch(() => undefined);
+  }
+
+  /** Subscribe to changes; returns an unsubscribe function. */
+  onChange(listener: (stats: PersonalStats) => void): () => void {
+    const handler = () => {
+      void this.getAll().then(listener);
+    };
+    chrome.storage.sync.onChanged.addListener(handler);
+    return () => chrome.storage.sync.onChanged.removeListener(handler);
+  }
+}

--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -1,8 +1,10 @@
 import { ActionGuard } from "@/application/ActionGuard";
-import type { SettingsProvider } from "@/application/ports";
+import type { SettingsProvider, StatsRecorder } from "@/application/ports";
 import { RoomSession } from "@/application/RoomSession";
 import { DEFAULT_SETTINGS, type Settings } from "@/domain/settings";
+import type { ReactionType } from "@/domain/reactions";
 import { ReactNotifier } from "@/infrastructure/notifier/ReactNotifier";
+import { ChromePersonalStatsRepository } from "@/infrastructure/storage/ChromePersonalStatsRepository";
 import { ChromeStorageSettingsRepository } from "@/infrastructure/storage/ChromeStorageSettingsRepository";
 import { WEBSOCKET_ENDPOINT } from "@/infrastructure/env";
 import { PartyWebSocketClient } from "@/infrastructure/ws/PartyWebSocketClient";
@@ -31,6 +33,16 @@ let currentSettings: Settings = DEFAULT_SETTINGS;
 const settings: SettingsProvider = { current: () => currentSettings };
 void settingsRepo.getAll().then((s) => (currentSettings = s));
 settingsRepo.onChange((s) => (currentSettings = s));
+
+// --- personal stats (client-only, independent of the backend) ---------------
+const statsRepo = new ChromePersonalStatsRepository();
+const stats: StatsRecorder = {
+  roomCreated: () => void statsRepo.incrementRoomsCreated(),
+  roomJoined: () => void statsRepo.incrementRoomsJoined(),
+  reactionSent: (type: ReactionType) => void statsRepo.incrementReaction(type),
+  connectionEnded: (durationMs: number) =>
+    void statsRepo.addConnectionMs(durationMs),
+};
 
 // --- composition root -------------------------------------------------------
 const guard = new ActionGuard();
@@ -74,6 +86,7 @@ const session = new RoomSession({
   notifier,
   settings,
   guard,
+  stats,
 });
 
 sidebarStore.setMode(mode);

--- a/src/presentation/popup/PersonalStatsPanel.stories.tsx
+++ b/src/presentation/popup/PersonalStatsPanel.stories.tsx
@@ -1,0 +1,84 @@
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+
+import { emptyStats, type PersonalStats } from "@/domain/personalStats";
+
+import { PersonalStatsPanel } from "./PersonalStatsPanel";
+
+const STORAGE_KEY = "personal_stats";
+
+/**
+ * Provides an in-memory chrome.storage.sync so the stats panel can render in
+ * Storybook (outside the extension context), seeded with `initial` stats.
+ */
+function withChromeMock(initial: PersonalStats | null): Decorator {
+  return (Story) => {
+    const store: Record<string, unknown> = {};
+    if (initial) store[STORAGE_KEY] = initial;
+    const listeners: Array<() => void> = [];
+    const mock = {
+      storage: {
+        sync: {
+          get: (keys: string[]) => {
+            const result: Record<string, unknown> = {};
+            for (const key of keys) {
+              if (key in store) result[key] = store[key];
+            }
+            return Promise.resolve(result);
+          },
+          set: (items: Record<string, unknown>) => {
+            Object.assign(store, items);
+            listeners.forEach((listener) => listener());
+            return Promise.resolve();
+          },
+          onChanged: {
+            addListener: (cb: () => void) => listeners.push(cb),
+            removeListener: (cb: () => void) => {
+              const index = listeners.indexOf(cb);
+              if (index >= 0) listeners.splice(index, 1);
+            },
+          },
+        },
+      },
+    };
+    (globalThis as { chrome?: unknown }).chrome = mock;
+    return (
+      <div className="w-[360px] bg-background p-4 text-foreground">
+        <Story />
+      </div>
+    );
+  };
+}
+
+const populated: PersonalStats = {
+  roomsCreated: 12,
+  roomsJoined: 34,
+  reactionsByType: {
+    fav: 58,
+    thumbs_up: 41,
+    smile: 27,
+    cry: 9,
+    middle_finger: 3,
+  },
+  connectionMs: (5 * 60 + 42) * 60 * 1000, // 5時間42分
+  since: new Date("2026-01-15").getTime(),
+};
+
+const meta: Meta<typeof PersonalStatsPanel> = {
+  title: "Popup/PersonalStatsPanel",
+  component: PersonalStatsPanel,
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PersonalStatsPanel>;
+
+/** A returning user with plenty of accumulated activity. */
+export const Populated: Story = {
+  decorators: [withChromeMock(populated)],
+};
+
+/** First run: nothing recorded yet. */
+export const Empty: Story = {
+  decorators: [withChromeMock(emptyStats())],
+};

--- a/src/presentation/popup/PersonalStatsPanel.tsx
+++ b/src/presentation/popup/PersonalStatsPanel.tsx
@@ -107,9 +107,12 @@ export function PersonalStatsPanel(): React.JSX.Element {
               const meta = REACTION_META[type];
               return (
                 <li key={type} className="flex items-center gap-2">
-                  <span className="flex w-20 shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
-                    <span aria-hidden>{meta.emoji}</span>
-                    <span className="truncate">{meta.label}</span>
+                  <span
+                    className="shrink-0 text-sm"
+                    aria-label={meta.label}
+                    title={meta.label}
+                  >
+                    {meta.emoji}
                   </span>
                   <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
                     <span
@@ -130,7 +133,7 @@ export function PersonalStatsPanel(): React.JSX.Element {
       {/* Reset + measuring-since footnote */}
       <div className="flex items-center justify-between gap-2 px-1">
         <p className="text-[11px] text-muted-foreground">
-          {since ? `${since} から計測` : "ローカルにのみ保存されます"}
+          {since ? `${since} から計測` : "ブラウザに保存されます"}
         </p>
         {confirming ? (
           <span className="flex items-center gap-1">

--- a/src/presentation/popup/PersonalStatsPanel.tsx
+++ b/src/presentation/popup/PersonalStatsPanel.tsx
@@ -1,0 +1,170 @@
+import { Clock, DoorOpen, RotateCcw, Smile, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { totalReactions } from "@/domain/personalStats";
+import { REACTION_TYPES, REACTION_META } from "@/domain/reactions";
+
+import { usePersonalStats } from "./usePersonalStats";
+
+/** Format a millisecond duration as a compact Japanese "Xh Ym" string. */
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60000);
+  if (totalMinutes < 1) return "1分未満";
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes}分`;
+  return `${hours}時間${minutes}分`;
+}
+
+/** Format the "measuring since" epoch as a YYYY/M/D date. */
+function formatSince(since: number | null): string | null {
+  if (since === null) return null;
+  const d = new Date(since);
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Clock;
+  label: string;
+  value: string;
+}): React.JSX.Element {
+  return (
+    <div className="rounded-xl border bg-card p-3 shadow-sm">
+      <div className="flex items-center gap-1.5 text-muted-foreground">
+        <Icon className="size-3.5" aria-hidden />
+        <p className="text-xs">{label}</p>
+      </div>
+      <p className="mt-1.5 text-2xl font-bold tabular-nums leading-none">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The "統計" tab: per-account usage figures accumulated entirely on the client
+ * (independent of the backend). Mirrors, on a personal scale, the aggregate
+ * dashboard the frontend `/stats` page shows for the whole service.
+ */
+export function PersonalStatsPanel(): React.JSX.Element {
+  const { stats, reset } = usePersonalStats();
+  const [confirming, setConfirming] = useState(false);
+
+  const reactionTotal = totalReactions(stats);
+  const maxReaction = Math.max(
+    1,
+    ...REACTION_TYPES.map((t) => stats.reactionsByType[t]),
+  );
+  const since = formatSince(stats.since);
+
+  const doReset = async (): Promise<void> => {
+    await reset();
+    setConfirming(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Headline figures */}
+      <div className="grid grid-cols-2 gap-2">
+        <StatCard
+          icon={Sparkles}
+          label="作成したルーム"
+          value={stats.roomsCreated.toLocaleString()}
+        />
+        <StatCard
+          icon={DoorOpen}
+          label="参加したルーム"
+          value={stats.roomsJoined.toLocaleString()}
+        />
+        <StatCard
+          icon={Smile}
+          label="送ったリアクション"
+          value={reactionTotal.toLocaleString()}
+        />
+        <StatCard
+          icon={Clock}
+          label="接続時間"
+          value={formatDuration(stats.connectionMs)}
+        />
+      </div>
+
+      {/* Reaction breakdown by kind */}
+      <section className="rounded-xl border bg-card p-4 shadow-sm">
+        <h2 className="mb-3 text-sm font-semibold">リアクション内訳</h2>
+        {reactionTotal === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            まだリアクションを送っていません。
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {REACTION_TYPES.map((type) => {
+              const count = stats.reactionsByType[type];
+              const meta = REACTION_META[type];
+              return (
+                <li key={type} className="flex items-center gap-2">
+                  <span className="flex w-20 shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                    <span aria-hidden>{meta.emoji}</span>
+                    <span className="truncate">{meta.label}</span>
+                  </span>
+                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                    <span
+                      className="block h-full rounded-full bg-red-600 transition-all"
+                      style={{ width: `${(count / maxReaction) * 100}%` }}
+                    />
+                  </span>
+                  <span className="w-8 shrink-0 text-right text-xs tabular-nums">
+                    {count.toLocaleString()}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Reset + measuring-since footnote */}
+      <div className="flex items-center justify-between gap-2 px-1">
+        <p className="text-[11px] text-muted-foreground">
+          {since ? `${since} から計測` : "ローカルにのみ保存されます"}
+        </p>
+        {confirming ? (
+          <span className="flex items-center gap-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={() => setConfirming(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 bg-red-600 px-2 text-xs text-white hover:bg-red-700"
+              onClick={() => void doReset()}
+            >
+              リセットする
+            </Button>
+          </span>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setConfirming(true)}
+          >
+            <RotateCcw className="size-3.5" aria-hidden />
+            リセット
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -141,7 +141,7 @@ export function PopupApp(): React.JSX.Element {
   );
 
   return (
-    <div className="bg-background text-foreground">
+    <div className="flex min-h-[480px] flex-col bg-background text-foreground">
       {/* Header */}
       <header className="border-b-2 border-red-600 bg-neutral-950 px-5 py-4 text-white">
         <div className="flex items-center gap-3">
@@ -257,7 +257,7 @@ export function PopupApp(): React.JSX.Element {
         </TabsContent>
       </Tabs>
 
-      <footer className="px-4 pb-3 text-center text-[11px] text-muted-foreground">
+      <footer className="mt-auto px-4 pb-3 pt-3 text-center text-[11px] text-muted-foreground">
         v{appVersion()} · powered by U-Not
       </footer>
     </div>

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -1,4 +1,5 @@
 import {
+  BarChart3,
   Bell,
   Check,
   ChevronDown,
@@ -8,6 +9,7 @@ import {
   MonitorPlay,
   Pencil,
   PictureInPicture2,
+  Settings as SettingsIcon,
   SlidersHorizontal,
   Smile,
   User,
@@ -19,8 +21,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { type Settings } from "@/domain/settings";
 
+import { PersonalStatsPanel } from "./PersonalStatsPanel";
 import { useSettings } from "./useSettings";
 
 type ToggleKey = Exclude<keyof Settings, "userName">;
@@ -151,83 +155,107 @@ export function PopupApp(): React.JSX.Element {
         </div>
       </header>
 
-      <main className="space-y-3 p-4">
-        {/* User settings */}
-        <section className="rounded-xl border bg-card p-4 shadow-sm">
-          <div className="mb-3 flex items-center gap-2">
-            <User className="size-4 text-red-600" aria-hidden />
-            <h2 className="text-sm font-semibold">ユーザー設定</h2>
-          </div>
-          {editing ? (
-            <form className="flex flex-col gap-1.5" onSubmit={submitName}>
-              <Label htmlFor="user-name" className="text-xs text-muted-foreground">
-                表示名（15文字以下）
-              </Label>
-              <div className="flex items-center gap-2">
-                <Input
-                  ref={inputRef}
-                  id="user-name"
-                  className="flex-1"
-                  maxLength={15}
-                  placeholder="あなたの名前"
-                  value={draftName}
-                  onChange={(e) => setDraftName(e.target.value)}
-                />
-                <Button
-                  type="submit"
-                  size="icon"
-                  variant="ghost"
-                  className="text-red-600 hover:text-red-600"
-                  aria-label="表示名を確定"
-                >
-                  <Check className="size-5" aria-hidden />
-                </Button>
-              </div>
-            </form>
-          ) : (
-            <div className="flex flex-col gap-1.5">
-              <span className="text-xs text-muted-foreground">表示名</span>
-              <div className="flex items-center gap-2">
-                <p className="flex-1 truncate text-sm font-medium">
-                  {settings.userName || (
-                    <span className="text-muted-foreground">未設定</span>
-                  )}
-                </p>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="text-muted-foreground hover:text-foreground"
-                  onClick={startEditing}
-                  aria-label={saved ? "保存しました" : "表示名を編集"}
-                >
-                  {saved ? (
-                    <Check className="size-5 text-red-600" aria-hidden />
-                  ) : (
-                    <Pencil className="size-5" aria-hidden />
-                  )}
-                </Button>
-              </div>
-            </div>
-          )}
-        </section>
+      <Tabs defaultValue="settings" className="gap-0">
+        <TabsList className="mx-4 mt-3 w-auto">
+          <TabsTrigger value="settings">
+            <SettingsIcon className="size-3.5" aria-hidden />
+            設定
+          </TabsTrigger>
+          <TabsTrigger value="stats">
+            <BarChart3 className="size-3.5" aria-hidden />
+            統計
+          </TabsTrigger>
+        </TabsList>
 
-        {/* Watch-party settings */}
-        <ToggleSection
-          title="同時視聴設定"
-          icon={MonitorPlay}
-          toggles={SYNC_TOGGLES}
-          renderToggle={renderToggle}
-        />
+        <TabsContent value="settings">
+          <main className="space-y-3 p-4">
+            {/* User settings */}
+            <section className="rounded-xl border bg-card p-4 shadow-sm">
+              <div className="mb-3 flex items-center gap-2">
+                <User className="size-4 text-red-600" aria-hidden />
+                <h2 className="text-sm font-semibold">ユーザー設定</h2>
+              </div>
+              {editing ? (
+                <form className="flex flex-col gap-1.5" onSubmit={submitName}>
+                  <Label
+                    htmlFor="user-name"
+                    className="text-xs text-muted-foreground"
+                  >
+                    表示名（15文字以下）
+                  </Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      ref={inputRef}
+                      id="user-name"
+                      className="flex-1"
+                      maxLength={15}
+                      placeholder="あなたの名前"
+                      value={draftName}
+                      onChange={(e) => setDraftName(e.target.value)}
+                    />
+                    <Button
+                      type="submit"
+                      size="icon"
+                      variant="ghost"
+                      className="text-red-600 hover:text-red-600"
+                      aria-label="表示名を確定"
+                    >
+                      <Check className="size-5" aria-hidden />
+                    </Button>
+                  </div>
+                </form>
+              ) : (
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs text-muted-foreground">表示名</span>
+                  <div className="flex items-center gap-2">
+                    <p className="flex-1 truncate text-sm font-medium">
+                      {settings.userName || (
+                        <span className="text-muted-foreground">未設定</span>
+                      )}
+                    </p>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className="text-muted-foreground hover:text-foreground"
+                      onClick={startEditing}
+                      aria-label={saved ? "保存しました" : "表示名を編集"}
+                    >
+                      {saved ? (
+                        <Check className="size-5 text-red-600" aria-hidden />
+                      ) : (
+                        <Pencil className="size-5" aria-hidden />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </section>
 
-        {/* Utility settings (kept last) */}
-        <ToggleSection
-          title="ユーティリティ設定"
-          icon={SlidersHorizontal}
-          toggles={UTILITY_TOGGLES}
-          renderToggle={renderToggle}
-        />
-      </main>
+            {/* Watch-party settings */}
+            <ToggleSection
+              title="同時視聴設定"
+              icon={MonitorPlay}
+              toggles={SYNC_TOGGLES}
+              renderToggle={renderToggle}
+            />
+
+            {/* Utility settings (kept last) */}
+            <ToggleSection
+              title="ユーティリティ設定"
+              icon={SlidersHorizontal}
+              toggles={UTILITY_TOGGLES}
+              renderToggle={renderToggle}
+            />
+          </main>
+        </TabsContent>
+
+        <TabsContent value="stats">
+          <main className="p-4">
+            <PersonalStatsPanel />
+          </main>
+        </TabsContent>
+      </Tabs>
 
       <footer className="px-4 pb-3 text-center text-[11px] text-muted-foreground">
         v{appVersion()} · powered by U-Not
@@ -269,7 +297,9 @@ function ToggleSection({
           aria-hidden
         />
       </button>
-      {open && <div className="mt-1 space-y-0.5">{toggles.map(renderToggle)}</div>}
+      {open && (
+        <div className="mt-1 space-y-0.5">{toggles.map(renderToggle)}</div>
+      )}
     </section>
   );
 }

--- a/src/presentation/popup/styles.css
+++ b/src/presentation/popup/styles.css
@@ -92,4 +92,7 @@ body {
 
 #root {
   width: 360px;
+  /* Keep the popup comfortably tall by default so switching between the
+     設定 / 統計 tabs doesn't make the window jump in height. */
+  min-height: 480px;
 }

--- a/src/presentation/popup/usePersonalStats.ts
+++ b/src/presentation/popup/usePersonalStats.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { emptyStats, type PersonalStats } from "@/domain/personalStats";
+import { ChromePersonalStatsRepository } from "@/infrastructure/storage/ChromePersonalStatsRepository";
+
+const repo = new ChromePersonalStatsRepository();
+
+export interface UsePersonalStats {
+  /** Current stats (zeros until the first read resolves). */
+  stats: PersonalStats;
+  /** True once the initial read from chrome.storage has completed. */
+  loaded: boolean;
+  /** Clear all accumulated statistics back to zero. */
+  reset: () => Promise<void>;
+}
+
+/**
+ * React binding over {@link ChromePersonalStatsRepository}. Mirrors the stored
+ * stats into React state and stays in sync with writes made from any extension
+ * context (e.g. the player content script) via `chrome.storage` change events.
+ */
+export function usePersonalStats(): UsePersonalStats {
+  const [stats, setStats] = useState<PersonalStats>(emptyStats);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void repo.getAll().then((value) => {
+      if (!active) return;
+      setStats(value);
+      setLoaded(true);
+    });
+    const unsubscribe = repo.onChange((value) => {
+      if (active) setStats(value);
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const reset = useCallback(async () => {
+    setStats(emptyStats());
+    await repo.reset();
+  }, []);
+
+  return { stats, loaded, reset };
+}


### PR DESCRIPTION
## 概要

popup に「設定 / 統計」タブを追加し、クライアント側だけで蓄積する個人利用統計を表示する。バックエンドとは独立し、`chrome.storage.sync` に保存（Chrome プロファイル単位で同期）。

## 変更点

- **統計タブ**: 作成/参加ルーム数・送信リアクション・接続時間・リアクション内訳・リセット機能。
- **フッター固定**: バージョン/クレジット表記を popup 最下部に固定（コンテンツが短いタブでも下に張り付く）。
- **リアクション内訳の整理**: 見切れていたラベル文字を削除し絵文字のみ表示（ラベルは `aria-label`/`title` に保持）。
- **保存先の説明修正**: `chrome.storage.sync` の実態に合わせ「ブラウザに保存されます」に変更。

## 確認

- `pnpm typecheck` ✅
- `pnpm lint` ✅

> UI 結合の最終確認は dアニメストア実機で要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)