### PR TITLE
feat(popup): 情報タブ・アコーディオン・アニメーション追加

### DIFF
--- a/src/infrastructure/env.ts
+++ b/src/infrastructure/env.ts
@@ -21,6 +21,13 @@ export const WEBSOCKET_PROTOCOL = IS_PRODUCTION ? "wss://" : "ws://";
 export const API_ENDPOINT = `${BACKEND_PROTOCOL}${BACKEND_HOST}api/v1/`;
 export const VERSION_CHECK_ENDPOINT = `${API_ENDPOINT}chrome-extension/version-check`;
 
+/**
+ * 公開サイト（ホームページ・使い方）の URL。バックエンドと同一ホストで配信されるため、
+ * dev では `http://localhost/`、本番では `https://d-party.net/` を指す。
+ */
+export const SITE_URL = `${BACKEND_PROTOCOL}${BACKEND_HOST}`;
+export const USAGE_URL = `${SITE_URL}usage`;
+
 export const ANIMESTORE_HOST = `${BACKEND_HOST}anime-store/`;
 export const WEBSOCKET_ENDPOINT = `${WEBSOCKET_PROTOCOL}${ANIMESTORE_HOST}party/`;
 export const ANIMESTORE_REDIRECT_ENDPOINT = `${BACKEND_PROTOCOL}${ANIMESTORE_HOST}lobby/`;

--- a/src/presentation/popup/InfoPanel.tsx
+++ b/src/presentation/popup/InfoPanel.tsx
@@ -1,0 +1,77 @@
+import { BookOpen, ExternalLink, Heart, Home } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+import { FaChrome } from "react-icons/fa6";
+
+import { SITE_URL, USAGE_URL } from "@/infrastructure/env";
+
+interface InfoLink {
+  href: string;
+  label: string;
+  description: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  /** Highlight the link (e.g. the sponsor call-to-action). */
+  accent?: boolean;
+}
+
+/** External destinations shown in the popup's「情報」tab. */
+const LINKS: InfoLink[] = [
+  {
+    href: SITE_URL,
+    label: "ホームページ",
+    description: "d-party の公式サイト",
+    icon: Home,
+  },
+  {
+    href: USAGE_URL,
+    label: "使い方",
+    description: "同時視聴の始め方ガイド",
+    icon: BookOpen,
+  },
+  {
+    href: "https://chrome.google.com/webstore/detail/d-party/ibmlcfpijglpfbfgaleaeooebgdgcbpc?hl=ja",
+    label: "Chrome ウェブストア",
+    description: "拡張機能ページ・レビュー投稿",
+    icon: FaChrome,
+  },
+  {
+    href: "https://github.com/sponsors/d-party",
+    label: "寄付（GitHub Sponsors）",
+    description: "開発を支援して d-party を応援する",
+    icon: Heart,
+    accent: true,
+  },
+];
+
+export function InfoPanel(): React.JSX.Element {
+  return (
+    <section className="rounded-xl border bg-card p-2 shadow-sm">
+      <ul className="space-y-0.5">
+        {LINKS.map(({ href, label, description, icon: Icon, accent }) => (
+          <li key={href}>
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/70"
+            >
+              <Icon
+                className={`size-4 shrink-0 ${
+                  accent ? "text-red-600" : "text-muted-foreground"
+                }`}
+                aria-hidden
+              />
+              <span className="flex flex-col">
+                <span className="text-sm font-medium leading-tight">{label}</span>
+                <span className="text-xs text-muted-foreground">{description}</span>
+              </span>
+              <ExternalLink
+                className="ml-auto size-3.5 shrink-0 text-muted-foreground"
+                aria-hidden
+              />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
   BarChart3,
   Bell,
@@ -5,6 +6,7 @@ import {
   ChevronDown,
   ExternalLink,
   Eye,
+  Info,
   type LucideIcon,
   MonitorPlay,
   Pencil,
@@ -24,6 +26,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { type Settings } from "@/domain/settings";
 
+import { InfoPanel } from "./InfoPanel";
 import { PersonalStatsPanel } from "./PersonalStatsPanel";
 import { useSettings } from "./useSettings";
 
@@ -91,12 +94,34 @@ function appVersion(): string {
   }
 }
 
+/**
+ * Inactive panels stay laid out but invisible, so the popup never jumps when
+ * switching tabs.
+ */
+const HIDDEN_WHEN_INACTIVE =
+  "data-[state=inactive]:invisible data-[state=inactive]:pointer-events-none";
+
+/**
+ * The 統計 panel stays in normal flow and fixes the popup's height (a stable
+ * reference). The other panels overlay it absolutely and scroll internally when
+ * their content is taller — e.g. when every 設定 toggle section is expanded —
+ * instead of stretching the window.
+ */
+const REFERENCE_PANEL = HIDDEN_WHEN_INACTIVE;
+const OVERLAY_PANEL = `absolute inset-0 overflow-y-auto ${HIDDEN_WHEN_INACTIVE}`;
+
 export function PopupApp(): React.JSX.Element {
   const { settings, update } = useSettings();
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState("");
   const [saved, setSaved] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Only one settings section is expanded at a time (accordion); opening one
+  // collapses any other that is already open.
+  const [openSection, setOpenSection] = useState<string | null>(null);
+  const toggleSection = (id: string): void =>
+    setOpenSection((current) => (current === id ? null : id));
+  const reduce = useReducedMotion();
 
   const startEditing = (): void => {
     setDraftName(settings.userName);
@@ -119,7 +144,13 @@ export function PopupApp(): React.JSX.Element {
     window.setTimeout(() => setSaved(false), 1500);
   };
 
-  const renderToggle = ({ key, label, description, icon: Icon, invert }: Toggle) => (
+  const renderToggle = ({
+    key,
+    label,
+    description,
+    icon: Icon,
+    invert,
+  }: Toggle) => (
     <label
       key={key}
       htmlFor={key}
@@ -135,13 +166,20 @@ export function PopupApp(): React.JSX.Element {
       <Switch
         id={key}
         checked={invert ? !settings[key] : settings[key]}
-        onCheckedChange={(checked) => void update(key, invert ? !checked : checked)}
+        onCheckedChange={(checked) =>
+          void update(key, invert ? !checked : checked)
+        }
       />
     </label>
   );
 
   return (
-    <div className="flex min-h-[480px] flex-col bg-background text-foreground">
+    <motion.div
+      initial={reduce ? false : { opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+      className="flex min-h-[480px] flex-col bg-background text-foreground"
+    >
       {/* Header */}
       <header className="border-b-2 border-red-600 bg-neutral-950 px-5 py-4 text-white">
         <div className="flex items-center gap-3">
@@ -149,8 +187,12 @@ export function PopupApp(): React.JSX.Element {
             <Users className="size-5 text-red-600" aria-hidden />
           </div>
           <div className="leading-tight">
-            <h1 className="text-base font-bold tracking-tight text-red-600">d-party</h1>
-            <p className="text-xs text-white/70">dアニメストア 同時視聴の設定</p>
+            <h1 className="text-base font-bold tracking-tight text-red-600">
+              d-party
+            </h1>
+            <p className="text-xs text-white/70">
+              dアニメストア 同時視聴の設定
+            </p>
           </div>
         </div>
       </header>
@@ -165,127 +207,150 @@ export function PopupApp(): React.JSX.Element {
             <BarChart3 className="size-3.5" aria-hidden />
             統計
           </TabsTrigger>
+          <TabsTrigger value="info">
+            <Info className="size-3.5" aria-hidden />
+            情報
+          </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="settings">
-          <main className="space-y-3 p-4">
-            {/* User settings */}
-            <section className="rounded-xl border bg-card p-4 shadow-sm">
-              <div className="mb-3 flex items-center gap-2">
-                <User className="size-4 text-red-600" aria-hidden />
-                <h2 className="text-sm font-semibold">ユーザー設定</h2>
-              </div>
-              {editing ? (
-                <form className="flex flex-col gap-1.5" onSubmit={submitName}>
-                  <Label
-                    htmlFor="user-name"
-                    className="text-xs text-muted-foreground"
-                  >
-                    表示名（15文字以下）
-                  </Label>
-                  <div className="flex items-center gap-2">
-                    <Input
-                      ref={inputRef}
-                      id="user-name"
-                      className="flex-1"
-                      maxLength={15}
-                      placeholder="あなたの名前"
-                      value={draftName}
-                      onChange={(e) => setDraftName(e.target.value)}
-                    />
-                    <Button
-                      type="submit"
-                      size="icon"
-                      variant="ghost"
-                      className="text-red-600 hover:text-red-600"
-                      aria-label="表示名を確定"
-                    >
-                      <Check className="size-5" aria-hidden />
-                    </Button>
-                  </div>
-                </form>
-              ) : (
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-xs text-muted-foreground">表示名</span>
-                  <div className="flex items-center gap-2">
-                    <p className="flex-1 truncate text-sm font-medium">
-                      {settings.userName || (
-                        <span className="text-muted-foreground">未設定</span>
-                      )}
-                    </p>
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      className="text-muted-foreground hover:text-foreground"
-                      onClick={startEditing}
-                      aria-label={saved ? "保存しました" : "表示名を編集"}
-                    >
-                      {saved ? (
-                        <Check className="size-5 text-red-600" aria-hidden />
-                      ) : (
-                        <Pencil className="size-5" aria-hidden />
-                      )}
-                    </Button>
-                  </div>
+        <div className="relative">
+          <TabsContent value="settings" forceMount className={OVERLAY_PANEL}>
+            <main className="space-y-3 p-4">
+              {/* User settings */}
+              <section className="rounded-xl border bg-card p-4 shadow-sm">
+                <div className="mb-3 flex items-center gap-2">
+                  <User className="size-4 text-red-600" aria-hidden />
+                  <h2 className="text-sm font-semibold">ユーザー設定</h2>
                 </div>
-              )}
-            </section>
+                {editing ? (
+                  <form className="flex flex-col gap-1.5" onSubmit={submitName}>
+                    <Label
+                      htmlFor="user-name"
+                      className="text-xs text-muted-foreground"
+                    >
+                      表示名（15文字以下）
+                    </Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        ref={inputRef}
+                        id="user-name"
+                        className="flex-1"
+                        maxLength={15}
+                        placeholder="あなたの名前"
+                        value={draftName}
+                        onChange={(e) => setDraftName(e.target.value)}
+                      />
+                      <Button
+                        type="submit"
+                        size="icon"
+                        variant="ghost"
+                        className="text-red-600 hover:text-red-600"
+                        aria-label="表示名を確定"
+                      >
+                        <Check className="size-5" aria-hidden />
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs text-muted-foreground">
+                      表示名
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <p className="flex-1 truncate text-sm font-medium">
+                        {settings.userName || (
+                          <span className="text-muted-foreground">未設定</span>
+                        )}
+                      </p>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-foreground"
+                        onClick={startEditing}
+                        aria-label={saved ? "保存しました" : "表示名を編集"}
+                      >
+                        {saved ? (
+                          <Check className="size-5 text-red-600" aria-hidden />
+                        ) : (
+                          <Pencil className="size-5" aria-hidden />
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </section>
 
-            {/* Watch-party settings */}
-            <ToggleSection
-              title="同時視聴設定"
-              icon={MonitorPlay}
-              toggles={SYNC_TOGGLES}
-              renderToggle={renderToggle}
-            />
+              {/* Watch-party settings */}
+              <ToggleSection
+                title="同時視聴設定"
+                icon={MonitorPlay}
+                toggles={SYNC_TOGGLES}
+                renderToggle={renderToggle}
+                open={openSection === "sync"}
+                onToggle={() => toggleSection("sync")}
+              />
 
-            {/* Utility settings (kept last) */}
-            <ToggleSection
-              title="ユーティリティ設定"
-              icon={SlidersHorizontal}
-              toggles={UTILITY_TOGGLES}
-              renderToggle={renderToggle}
-            />
-          </main>
-        </TabsContent>
+              {/* Utility settings (kept last) */}
+              <ToggleSection
+                title="ユーティリティ設定"
+                icon={SlidersHorizontal}
+                toggles={UTILITY_TOGGLES}
+                renderToggle={renderToggle}
+                open={openSection === "utility"}
+                onToggle={() => toggleSection("utility")}
+              />
+            </main>
+          </TabsContent>
 
-        <TabsContent value="stats">
-          <main className="p-4">
-            <PersonalStatsPanel />
-          </main>
-        </TabsContent>
+          <TabsContent value="stats" forceMount className={REFERENCE_PANEL}>
+            <main className="p-4">
+              <PersonalStatsPanel />
+            </main>
+          </TabsContent>
+
+          <TabsContent value="info" forceMount className={OVERLAY_PANEL}>
+            <main className="p-4">
+              <InfoPanel />
+            </main>
+          </TabsContent>
+        </div>
       </Tabs>
 
       <footer className="mt-auto px-4 pb-3 pt-3 text-center text-[11px] text-muted-foreground">
         v{appVersion()} · powered by U-Not
       </footer>
-    </div>
+    </motion.div>
   );
 }
 
 /**
- * A settings section that is collapsed by default and expands on click, so the
- * popup stays short enough to avoid scrolling until a section is opened.
+ * A settings section that expands on click. Open state is controlled by the
+ * parent so the sections behave as an accordion — opening one collapses any
+ * other that is already open.
  */
 function ToggleSection({
   title,
   icon: Icon,
   toggles,
   renderToggle,
+  open,
+  onToggle,
 }: {
   title: string;
   icon: LucideIcon;
   toggles: Toggle[];
   renderToggle: (toggle: Toggle) => React.JSX.Element;
+  open: boolean;
+  onToggle: () => void;
 }): React.JSX.Element {
-  const [open, setOpen] = useState(false);
+  const reduce = useReducedMotion();
   return (
     <section className="rounded-xl border bg-card p-2 shadow-sm">
       <button
         type="button"
         aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
+        onClick={onToggle}
         className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/70"
       >
         <Icon className="size-4 text-red-600" aria-hidden />
@@ -297,9 +362,22 @@ function ToggleSection({
           aria-hidden
         />
       </button>
-      {open && (
-        <div className="mt-1 space-y-0.5">{toggles.map(renderToggle)}</div>
-      )}
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={
+              reduce ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }
+            }
+            className="overflow-hidden"
+          >
+            <div className="mt-1 space-y-0.5">{toggles.map(renderToggle)}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 }


### PR DESCRIPTION
## 概要

ポップアップに「情報」タブを追加し、設定セクションのアコーディオン化とアニメーションを導入します。

## 変更点

### 情報タブの追加
- 新規 `InfoPanel.tsx`。以下4リンクを新規タブで開く形で配置:
  - ホームページ / 使い方（env 追従: dev=localhost、prod=d-party.net）
  - Chrome ウェブストア・GitHub Sponsors（固定 URL）
- `env.ts` に `SITE_URL` / `USAGE_URL` を追加。

### タブ高さの安定化
- 統計パネルを基準高さとして固定し、他パネルは重ねて表示。設定がトグル展開で長くなった場合はポップアップを伸ばさずパネル内スクロール。

### 設定セクションのアコーディオン化
- 開閉状態を親に持ち上げ、同時に開くのは常に1つ（別を開くと先に開いていた方が閉じる）。

### アニメーション（framer-motion）
- アコーディオンの開閉（height + opacity）。
- ポップアップ起動時の控えめなフェードイン。
- いずれも `prefers-reduced-motion` を尊重。

## 確認
- `pnpm typecheck` / `pnpm lint` / `pnpm build`（dev・prod）すべて成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)