### PR TITLE
docs: link published Storybook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ pnpm storybook        # UI コンポーネントカタログ
 `pnpm build` 後、`chrome://extensions` →「パッケージ化されていない拡張機能を読み込む」で
 `dist/` を選択します。
 
+### Storybook
+
+UI コンポーネントのカタログを Storybook で公開しています（`main` へのマージ時に GitHub Pages へ自動デプロイ）。
+
+- 公開先: <https://d-party.github.io/chrome-extension/>
+- ローカル: `pnpm storybook`（http://localhost:6006）
+
 ### 接続先の設定
 
 接続先は [`src/infrastructure/env.ts`](src/infrastructure/env.ts) に集約しています。


### PR DESCRIPTION
GitHub Pages へデプロイ済みの Storybook 公開先リンク（<https://d-party.github.io/chrome-extension/>）を README に追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)