### PR TITLE
ci: add dependency license-check workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,37 @@
+name: License Check
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  license-check:
+    name: Check dependency licenses
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Allow-list lives in license-whitelist-node.txt (one SPDX id per line).
+      # Fails the build if any production dependency reports a license not on the list,
+      # blocking GPL/AGPL/SSPL contamination. See that file for how to extend it.
+      - name: Check licenses
+        run: pnpm run license:check

--- a/license-whitelist-node.txt
+++ b/license-whitelist-node.txt
@@ -1,0 +1,29 @@
+# License whitelist for chrome-extension (Node) dependencies.
+# One SPDX license identifier per line. Blank lines and lines starting with # are ignored.
+# Consumed by the `license:check` npm script and the License Check CI workflow.
+#
+# Policy: permissive + weak copyleft only. Never add GPL / AGPL / SSPL here —
+# replace such a dependency with a permissively licensed alternative instead.
+
+# Permissive
+MIT
+Apache-2.0
+BSD-2-Clause
+BSD-3-Clause
+ISC
+0BSD
+
+# Creative Commons / public domain (documentation / data assets)
+CC0-1.0
+CC-BY-4.0
+CC-BY-3.0
+Public Domain
+
+# Other permissive
+Unlicense
+BlueOak-1.0.0
+Python-2.0
+MPL-2.0
+
+# Weak copyleft (safe for SaaS library use — LGPL does not require app source disclosure)
+LGPL-3.0-or-later

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "api:generate": "orval --config orval.config.ts",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "license:check": "pnpm dlx license-checker-rseidelsohn@5.0.1 --production --excludePrivatePackages --onlyAllow \"$(grep -v '^[[:space:]]*#' license-whitelist-node.txt | grep -v '^[[:space:]]*$' | paste -sd ';')\""
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.1",


### PR DESCRIPTION
## What

Add a **License Check** CI workflow that fails the build if any production dependency reports a license outside a permissive/weak-copyleft allow-list — blocking GPL/AGPL/SSPL contamination.

- `license-whitelist-node.txt` — SPDX allow-list, one id per line (`#` comments / blank lines ignored). Tailored to this repo's actual production dependencies.
- `license:check` npm script — runs `license-checker-rseidelsohn@5.0.1` (via `pnpm dlx`, so **no lockfile change**) driven by the txt file: `--production --excludePrivatePackages --onlyAllow`.
- `.github/workflows/license-check.yml` — runs `pnpm run license:check` on push / pull_request.

## Why

Mirrors the `backend` submodule's `pip-licenses`-based license gate, giving every d-party submodule the same license-compliance check. Allow-list is externalized to a txt file matching `license-whitelist-python.txt`.

## Verification

- `pnpm run license:check` exits **0** on the current dependency tree.
- Removing a needed license from the txt makes it exit **1** (gate works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)