### PR TITLE
feat(party): owner badge and hold-to-delete room control

### DIFF
--- a/src/application/RoomSession.ts
+++ b/src/application/RoomSession.ts
@@ -46,6 +46,9 @@ export class RoomSession {
   private _inRoom = false;
   private joined = false;
   private resetDelayMs = 100;
+  // ルーム削除など、意図的にソケットを閉じるときに true にして、onClose の
+  // 「サーバーとの通信が終了」誤アラートと UI 上書きを抑止する。
+  private intentionalTeardown = false;
   // ホスト以外は video_operation をブロードキャストしない。create成功または
   // host_change でホストになったときに true になる。
   private isHost = false;
@@ -122,6 +125,12 @@ export class RoomSession {
       onOpen: () => onOpen?.(),
       onMessage: (message) => this.handleMessage(message),
       onClose: () => {
+        // room_deleted などで自分から閉じた場合は専用ハンドラ側で UI を
+        // 処理済みなので、ここでの誤アラート・状態上書きを行わない。
+        if (this.intentionalTeardown) {
+          this.intentionalTeardown = false;
+          return;
+        }
         if (this.joined) {
           this.deps.notifier.alert(SERVER_DISCONNECTED);
         } else if (this._inRoom) {
@@ -217,6 +226,15 @@ export class RoomSession {
 
   requestUserList(): void {
     this.send({ action: "user_list", request_id: now() });
+  }
+
+  /**
+   * ホスト（オーナー）専用: ルームの削除を要求する。サーバはルーム内全員へ
+   * `room_deleted` をブロードキャストする（自分自身も受信して UI をリセットする）。
+   * ホスト以外が呼んでもサーバ側で無視される。
+   */
+  deleteRoom(): void {
+    this.send({ action: "delete_room", request_id: now() });
   }
 
   sendReaction(reactionType: ReactionType): void {
@@ -333,6 +351,8 @@ export class RoomSession {
             icon: "host",
             label: "ホスト権限を獲得しました",
           });
+        } else if (message.message_type === "room_deleted") {
+          this.handleRoomDeleted();
         } else if (message.message_type === "failed_join") {
           // ルームが既に存在しない/終了済み。サーバはこの直後に close するので、
           // onClose 側の誤った SERVER_DISCONNECTED ではなく明確なメッセージを出す。
@@ -394,6 +414,23 @@ export class RoomSession {
         }
         break;
     }
+  }
+
+  /**
+   * ホストがルームを削除したときの処理（削除実行者自身もこの経路を通る）。
+   * 通知を出し、セッションを片付けてソケットを閉じ、サイドバーを
+   * 「ルーム作成」段階へ戻す。
+   */
+  private handleRoomDeleted(): void {
+    this.intentionalTeardown = true;
+    this.joined = false;
+    this._inRoom = false;
+    this.stopHeartbeat();
+    this.endConnectionTracking();
+    this.isHost = false;
+    this.deps.client.close();
+    this.deps.notifier.alert("ルームが削除されました");
+    this.deps.sidebar.resetToCreate();
   }
 
   // 他の参加者の操作通知 (operation_notification) を受信したとき、トーストと

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -38,6 +38,8 @@ export interface SidebarView {
   addHistory(entry: HistoryEntryInput): void;
   updateUserList(users: User[]): void;
   hideSidebar(): void;
+  /** Reset the sidebar back to the room-creation stage (e.g. after the room is deleted). */
+  resetToCreate(): void;
 }
 
 /** Plays the on-screen reaction animations. */

--- a/src/domain/protocol.ts
+++ b/src/domain/protocol.ts
@@ -13,6 +13,11 @@ import type { ReactionType } from "./reactions";
 export interface User {
   user_id: string;
   user_name: string;
+  /**
+   * ルームのホスト（オーナー）かどうか。`user_list` で配信される。
+   * 旧バックエンド互換のため任意（未指定なら非ホスト扱い）。
+   */
+  is_host?: boolean;
 }
 
 /** Player state as reported by the extension (sent to the server). */
@@ -97,6 +102,12 @@ export interface UserListRequestMessage {
   request_id: number;
 }
 
+/** ホスト（オーナー）がルームを削除する要求。ホスト以外が送っても無視される。 */
+export interface DeleteRoomMessage {
+  action: "delete_room";
+  request_id: number;
+}
+
 export interface ReactionMessage {
   action: "reaction";
   reaction_type: ReactionType;
@@ -112,6 +123,7 @@ export type OutgoingMessage =
   | OperationNotificationMessage
   | LeaveMessage
   | UserListRequestMessage
+  | DeleteRoomMessage
   | ReactionMessage;
 
 // ---------------------------------------------------------------------------

--- a/src/presentation/content/party/index.ts
+++ b/src/presentation/content/party/index.ts
@@ -69,6 +69,12 @@ const { store: sidebarStore, controller: sidebarController } = mountSidebar({
     session.leave();
     sidebarStore.hide();
   },
+  onDeleteRoom: () => {
+    // ホスト（オーナー）のみ表示されるボタンからの要求。サーバ側でも
+    // 非ホストは無視されるが、念のため inRoom を確認してから送る。
+    if (!session.inRoom) return;
+    session.deleteRoom();
+  },
   onTabChange: (tab: SidebarTab) => {
     if (tab === "users") session.requestUserList();
   },

--- a/src/presentation/content/party/react/Sidebar.stories.tsx
+++ b/src/presentation/content/party/react/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import { Sidebar } from "./Sidebar";
 import { SidebarStore } from "./sidebarStore";
 
 const SAMPLE_USERS: User[] = [
-  { user_id: "1", user_name: "たかし" },
+  { user_id: "1", user_name: "たかし", is_host: true },
   { user_id: "2", user_name: "はなこ" },
   { user_id: "3", user_name: "AnonymousUser" },
 ];
@@ -21,6 +21,7 @@ function frame(store: SidebarStore) {
         store={store}
         onCreateRoom={() => store.setJoined(true)}
         onLeave={() => store.hide()}
+        onDeleteRoom={() => store.resetToCreate()}
         onTabChange={() => {}}
       />
     </div>
@@ -99,24 +100,40 @@ export const HistoryTab: Story = {
   },
 };
 
-/** Participants tab. */
+/** Participants tab. Self is also the owner, so the "you" + 王冠 badges co-exist. */
 export const UsersTab: Story = {
   render: () => {
     const store = new SidebarStore();
     store.setMode("join");
     store.setJoined(true);
     store.updateUsers(SAMPLE_USERS);
+    store.setSelfUserId("1");
     store.setActiveTab("users");
     return frame(store);
   },
 };
 
-/** Control tab with the leave action. */
+/** Control tab as a guest: only the leave action is available. */
 export const ControlTab: Story = {
   render: () => {
     const store = new SidebarStore();
     store.setMode("join");
     store.setJoined(true);
+    store.updateUsers(SAMPLE_USERS);
+    store.setSelfUserId("2");
+    store.setActiveTab("control");
+    return frame(store);
+  },
+};
+
+/** Control tab as the owner: the hold-to-delete room action is shown. */
+export const OwnerControlTab: Story = {
+  render: () => {
+    const store = new SidebarStore();
+    store.setMode("join");
+    store.setJoined(true);
+    store.updateUsers(SAMPLE_USERS);
+    store.setSelfUserId("1");
     store.setActiveTab("control");
     return frame(store);
   },

--- a/src/presentation/content/party/react/Sidebar.tsx
+++ b/src/presentation/content/party/react/Sidebar.tsx
@@ -29,6 +29,8 @@ export interface SidebarProps {
   onCreateRoom: () => void;
   /** Leave the room. */
   onLeave: () => void;
+  /** Delete the room (owner only). */
+  onDeleteRoom: () => void;
   /** Called when the active tab changes (used to refresh the user list). */
   onTabChange?: (tab: SidebarTab) => void;
 }
@@ -37,6 +39,7 @@ export function Sidebar({
   store,
   onCreateRoom,
   onLeave,
+  onDeleteRoom,
   onTabChange,
 }: SidebarProps): React.JSX.Element | null {
   const state = useSyncExternalStore(store.subscribe, store.getSnapshot);
@@ -82,6 +85,7 @@ export function Sidebar({
                 store={store}
                 onCreateRoom={onCreateRoom}
                 onLeave={onLeave}
+                onDeleteRoom={onDeleteRoom}
                 onTabChange={onTabChange}
               />
             </motion.div>
@@ -97,8 +101,12 @@ function Panel({
   store,
   onCreateRoom,
   onLeave,
+  onDeleteRoom,
   onTabChange,
 }: SidebarProps & { state: SidebarState }): React.JSX.Element {
+  const isOwner = state.users.some(
+    (user) => user.user_id === state.selfUserId && user.is_host === true,
+  );
   return (
     <div className="flex h-full w-80 flex-col bg-card text-card-foreground shadow-2xl ring-1 ring-border">
       <header className="flex items-center justify-between bg-neutral-950/50 px-3 py-2.5 text-white">
@@ -158,7 +166,11 @@ function Panel({
               <UsersPanel state={state} />
             </TabsContent>
             <TabsContent value="control">
-              <ControlPanel onLeave={onLeave} />
+              <ControlPanel
+                onLeave={onLeave}
+                onDeleteRoom={onDeleteRoom}
+                isOwner={isOwner}
+              />
             </TabsContent>
           </div>
         </Tabs>

--- a/src/presentation/content/party/react/mountSidebar.tsx
+++ b/src/presentation/content/party/react/mountSidebar.tsx
@@ -8,6 +8,7 @@ import { SidebarController, SidebarStore, type SidebarTab } from "./sidebarStore
 export interface SidebarHandlers {
   onCreateRoom: () => void;
   onLeave: () => void;
+  onDeleteRoom: () => void;
   onTabChange?: (tab: SidebarTab) => void;
 }
 
@@ -103,6 +104,7 @@ export function mountSidebar(handlers: SidebarHandlers): MountedSidebar {
         store={store}
         onCreateRoom={handlers.onCreateRoom}
         onLeave={handlers.onLeave}
+        onDeleteRoom={handlers.onDeleteRoom}
         onTabChange={handlers.onTabChange}
       />
     </PortalContainerContext.Provider>,

--- a/src/presentation/content/party/react/sidebar/panels.tsx
+++ b/src/presentation/content/party/react/sidebar/panels.tsx
@@ -1,8 +1,35 @@
-import { LogOut, PartyPopper, UserRound } from "lucide-react";
+import { Crown, LogOut, PartyPopper, Trash2, UserRound } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 import type { SidebarState } from "../sidebarStore";
+
+/** ルーム削除を確定するまでの長押し時間（誤操作防止）。 */
+const DELETE_HOLD_MS = 3000;
+
+/**
+ * オーナー（ホスト）を示す王冠バッジ。文字は持たず、ホバー（フォーカス）時に
+ * tooltip で「オーナー」と表示する。参加者リストとオーナー専用操作の見出しで使う。
+ */
+function OwnerBadge(): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-amber-400 text-amber-950">
+          <Crown className="size-3" aria-hidden />
+          <span className="sr-only">オーナー</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>オーナー</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export function CreatePanel({
   onCreateRoom,
@@ -35,6 +62,7 @@ export function UsersPanel({ state }: { state: SidebarState }): React.JSX.Elemen
       <ul className="flex flex-col gap-1">
         {state.users.map((user) => {
           const isSelf = user.user_id === state.selfUserId;
+          const isOwner = user.is_host === true;
           return (
             <li
               key={user.user_id}
@@ -42,9 +70,15 @@ export function UsersPanel({ state }: { state: SidebarState }): React.JSX.Elemen
             >
               <UserRound className="size-4 shrink-0 text-red-600" aria-hidden />
               <span className="truncate">{user.user_name}</span>
-              {isSelf && (
-                <span className="ml-auto shrink-0 rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-white">
-                  you
+              {/* you と owner が両方付く場合は you を左、owner を右に並べる。 */}
+              {(isSelf || isOwner) && (
+                <span className="ml-auto flex shrink-0 items-center gap-1">
+                  {isSelf && (
+                    <span className="rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none text-white">
+                      you
+                    </span>
+                  )}
+                  {isOwner && <OwnerBadge />}
                 </span>
               )}
             </li>
@@ -57,21 +91,132 @@ export function UsersPanel({ state }: { state: SidebarState }): React.JSX.Elemen
 
 export function ControlPanel({
   onLeave,
+  onDeleteRoom,
+  isOwner,
 }: {
   onLeave: () => void;
+  onDeleteRoom: () => void;
+  /** ローカルユーザーがルームのオーナー（ホスト）かどうか。 */
+  isOwner: boolean;
 }): React.JSX.Element {
   return (
-    <div className="flex flex-col gap-3 px-1">
-      <div>
-        <p className="text-sm font-semibold">パーティールームから退室</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          退室するとサイドバーが閉じます。
-        </p>
+    <div className="flex flex-col gap-8 px-1 pb-3 pt-6">
+      <div className="flex flex-col gap-3">
+        <div>
+          <p className="text-sm font-semibold">パーティールームから退室</p>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            退室するとサイドバーが閉じます。
+          </p>
+        </div>
+        <Button
+          variant="destructive"
+          size="lg"
+          className="w-full gap-1.5"
+          onClick={onLeave}
+        >
+          <LogOut className="size-4" aria-hidden /> 退室する
+        </Button>
       </div>
-      <Button variant="destructive" className="w-full gap-1.5" onClick={onLeave}>
-        <LogOut className="size-4" aria-hidden /> 退室する
-      </Button>
+
+      {isOwner && (
+        <div className="flex flex-col gap-3 border-t border-border pt-6">
+          <div>
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm font-semibold">ルームを削除</p>
+              <OwnerBadge />
+            </div>
+            <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+              オーナーのみが実行できます。全員が退室になります。誤操作防止のため
+              3 秒間長押しで削除します。
+            </p>
+          </div>
+          <HoldToDeleteButton onConfirm={onDeleteRoom} />
+        </div>
+      )}
     </div>
+  );
+}
+
+/**
+ * 3 秒間の長押しで {@link onConfirm} を発火するボタン。押している間は
+ * 背景が左から右へ満ちていくプログレスで残り時間を可視化する。
+ */
+function HoldToDeleteButton({
+  onConfirm,
+}: {
+  onConfirm: () => void;
+}): React.JSX.Element {
+  const [progress, setProgress] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+  const firedRef = useRef(false);
+
+  const cancelHold = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    startRef.current = null;
+    setProgress(0);
+  }, []);
+
+  const startHold = useCallback(() => {
+    if (rafRef.current !== null) return;
+    firedRef.current = false;
+    startRef.current = null;
+    // ローカルな再帰関数で rAF ループを回す（自己参照 useCallback は不可のため）。
+    const loop = (timestamp: number): void => {
+      if (startRef.current === null) startRef.current = timestamp;
+      const ratio = Math.min(1, (timestamp - startRef.current) / DELETE_HOLD_MS);
+      setProgress(ratio);
+      if (ratio >= 1) {
+        rafRef.current = null;
+        startRef.current = null;
+        if (!firedRef.current) {
+          firedRef.current = true;
+          onConfirm();
+        }
+        setProgress(0);
+        return;
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+  }, [onConfirm]);
+
+  // アンマウント時に進行中の rAF を確実に止める。
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  const holding = progress > 0;
+  const remaining = Math.ceil((1 - progress) * (DELETE_HOLD_MS / 1000));
+
+  return (
+    <button
+      type="button"
+      onPointerDown={(event) => {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        startHold();
+      }}
+      onPointerUp={cancelHold}
+      onPointerLeave={cancelHold}
+      onPointerCancel={cancelHold}
+      aria-label="ルームを削除（3秒長押し）"
+      className="relative h-10 w-full select-none overflow-hidden rounded-md border border-destructive/60 bg-destructive/10 px-3 text-sm font-semibold text-destructive transition-colors hover:bg-destructive/15"
+    >
+      <span
+        className="absolute inset-y-0 left-0 bg-destructive/30"
+        style={{ width: `${progress * 100}%` }}
+        aria-hidden
+      />
+      <span className="relative z-10 flex items-center justify-center gap-1.5">
+        <Trash2 className="size-4" aria-hidden />
+        {holding ? `押し続けて削除… ${remaining}` : "ルームを削除（3秒長押し）"}
+      </span>
+    </button>
   );
 }
 

--- a/src/presentation/content/party/react/sidebarStore.ts
+++ b/src/presentation/content/party/react/sidebarStore.ts
@@ -104,6 +104,23 @@ export class SidebarStore {
   toggleCollapsed(): void {
     this.patch({ collapsed: !this.state.collapsed });
   }
+  /**
+   * ルーム削除などで一連のセッションが終了したとき、サイドバーを「ルーム作成」
+   * 段階へ戻す。参加者・履歴・共有リンク等のセッション状態をクリアする。
+   */
+  resetToCreate(): void {
+    this.patch({
+      mode: "create",
+      visible: true,
+      joined: false,
+      connectionStatus: "idle",
+      activeTab: "share",
+      shareUrl: "",
+      users: [],
+      selfUserId: "",
+      history: [],
+    });
+  }
 
   addHistory(entry: HistoryEntryInput): void {
     this.patch({
@@ -145,6 +162,9 @@ export class SidebarController implements SidebarView {
   }
   hideSidebar(): void {
     this.store.hide();
+  }
+  resetToCreate(): void {
+    this.store.resetToCreate();
   }
 }
 


### PR DESCRIPTION
## What
- **Owner badge**: the room owner is marked in the participants list with a crown badge (icon only, tooltip "オーナー" on hover). When the local user is both owner and self, the crown sits to the right of the `you` badge. Derives ownership from the new `is_host` field on `user_list`.
- **Owner-only room deletion**: a new section in the control tab (shown only to the owner, labelled with the owner badge) with a 3-second hold-to-confirm button. A progress fill grows over the hold and releasing early cancels — preventing accidental deletion.
- **room_deleted handling**: every member shows a notification and the sidebar resets to the room-creation stage; the socket is torn down without the spurious disconnect alert.
- Control tab spacing loosened for readability.

## Protocol
- Adds outgoing `delete_room`; `room_deleted` arrives via the existing `server_message` shape. Mirrors the backend change (d-party/backend#175).

## Checks
- `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass.
- Storybook: `OwnerControlTab` / updated `UsersTab` / `ControlTab` stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)