### PR TITLE
fix: show connection time in whole hours past 1h

### DIFF
--- a/src/presentation/popup/PersonalStatsPanel.tsx
+++ b/src/presentation/popup/PersonalStatsPanel.tsx
@@ -7,14 +7,19 @@ import { REACTION_TYPES, REACTION_META } from "@/domain/reactions";
 
 import { usePersonalStats } from "./usePersonalStats";
 
-/** Format a millisecond duration as a compact Japanese "Xh Ym" string. */
+/**
+ * Format a millisecond duration as a compact Japanese string.
+ *
+ * Under an hour it reads "X分" (or "1分未満"); once it reaches an hour it shows
+ * whole hours only ("X時間"), dropping the trailing minutes. Hours never roll
+ * over into days — the count keeps accumulating as hours.
+ */
 function formatDuration(ms: number): string {
   const totalMinutes = Math.floor(ms / 60000);
   if (totalMinutes < 1) return "1分未満";
   const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (hours === 0) return `${minutes}分`;
-  return `${hours}時間${minutes}分`;
+  if (hours === 0) return `${totalMinutes}分`;
+  return `${hours}時間`;
 }
 
 /** Format the "measuring since" epoch as a YYYY/M/D date. */


### PR DESCRIPTION
## 概要

popup「統計」タブの **接続時間** の表示を調整。

- 1時間未満: 従来どおり `X分`（1分未満は `1分未満`）
- **1時間以上: `X時間` のみ表示**（末尾の分は表示しない）
- 時間は累積し続け、`日` には変換しない（例: `24時間`, `30時間`）

## 変更ファイル

- `src/presentation/popup/PersonalStatsPanel.tsx` の `formatDuration`

## 確認

- `pnpm typecheck` ✅
- `pnpm lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)