### PR TITLE
feat(ui): ボタンにホバー演出を追加し、Storybook の process is not defined を修正

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,6 +23,11 @@ const config: StorybookConfig = {
           "@": path.resolve(dirname, "../src"),
         },
       },
+      define: {
+        "process.env.D_PARTY_ENV": JSON.stringify(
+          process.env.D_PARTY_ENV ?? "development",
+        ),
+      },
     });
   },
 };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,17 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium cursor-pointer select-none transition-all duration-150 ease-out active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 active:shadow-sm",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 active:shadow-sm",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground hover:-translate-y-0.5 hover:shadow-sm active:translate-y-0 active:shadow-none",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:-translate-y-0.5 hover:shadow-md active:translate-y-0 active:shadow-sm",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/src/presentation/content/party/react/sidebar/panels.tsx
+++ b/src/presentation/content/party/react/sidebar/panels.tsx
@@ -205,7 +205,7 @@ function HoldToDeleteButton({
       onPointerLeave={cancelHold}
       onPointerCancel={cancelHold}
       aria-label="ルームを削除（3秒長押し）"
-      className="relative h-10 w-full select-none overflow-hidden rounded-md border border-destructive/60 bg-destructive/10 px-3 text-sm font-semibold text-destructive transition-colors hover:bg-destructive/15"
+      className="relative h-10 w-full cursor-pointer select-none overflow-hidden rounded-md border border-destructive/60 bg-destructive/10 px-3 text-sm font-semibold text-destructive transition-all duration-150 ease-out hover:bg-destructive/15 hover:-translate-y-0.5 hover:shadow-sm active:translate-y-0 active:shadow-none"
     >
       <span
         className="absolute inset-y-0 left-0 bg-destructive/30"


### PR DESCRIPTION
## 概要

- **ルームを作成 / 退室する などのボタンがボタンっぽくない** という指摘に対応し、共通の `Button` コンポーネントにホバー時のふんわり浮き上がり (`-translate-y-0.5`)・影 (`shadow-md`)・押下時のスケール (`active:scale-[0.97]`)・`cursor-pointer` を付与した。
- サイドバーの長押し削除ボタン (`HoldToDeleteButton`) にも同じホバー演出と `cursor-pointer` を追加した。
- Storybook 上で stories が `ReferenceError: process is not defined` で表示できなかった問題を修正した（rspack.DefinePlugin と同等の置換を Vite 側にも追加）。

## 変更

| 変更 | 影響範囲 |
| --- | --- |
| `src/components/ui/button.tsx` の variants 強化 | CreatePanel / ControlPanel / SharePanel / popup の全 Button |
| `HoldToDeleteButton` の className 調整 | ルーム削除ボタン |
| `.storybook/main.ts` の Vite `define` 追加 | Storybook での `process.env.D_PARTY_ENV` 解決 |

## 確認

- `pnpm typecheck` ✅
- 実機（dアニメストア）での視認は `pnpm build` → `chrome://extensions` で再読み込みして確認。
- Storybook は `pnpm run storybook` で再起動後にエラーが消えること。
