### PR TITLE
fix(store): エピソード一覧・詳細・ポップアップのボタンを刷新

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,25 +1,173 @@
-﻿
-.swiper-slide-active .itemModule a:first-child {
-    height: 100%;
-    width: 80% !important;
-}
+/*
+ * d-party — injected controls for the dアニメストア episode list (ci_pc / tp_pc).
+ *
+ * Overlay-only: we never touch dアニメストア's native list layout. The buttons
+ * float on top of the card as an absolutely-positioned overlay, so thumbnails,
+ * frames and the NEW tag keep their original styling. (The old version forced
+ * the <section> into flexbox and resized the link/icons by percentage, which
+ * stretched the row and drew a line between the thumbnail and its frame.)
+ */
 
-.play-btn ,.popper-btn{
-    height: 100%;
-    width: 10% !important;
-    align-self: flex-end ;
+/* Anchor for the overlay. Scoped to the episode list so other `.clearfix`
+   sections on the page are unaffected. position:relative alone does not change
+   the native layout of the card's children. */
+.itemModule.list section.clearfix {
     position: relative;
 }
 
-/* マウスオーバーで説明を表示するツールチップ（data-tooltip 属性を使用） */
-.play-btn[data-tooltip]::after,
-.popper-btn[data-tooltip]::after {
-    content: attr(data-tooltip);
+.dparty-overlay {
     position: absolute;
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-    /* material-icons クラスのフォントを上書きし、文字が記号化しないようにする */
+    /* Bottom-aligned so the buttons sit below the episode title instead of
+       colliding with it (vertical-center used to overlap longer titles). */
+    bottom: 8px;
+    right: 12px;
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    z-index: 10;
+    /* Let clicks in the gaps fall through to the underlying card link. */
+    pointer-events: none;
+}
+
+/* While a button is hovered, lift this overlay's whole stacking context to the
+   top so its tooltip is never hidden under a neighbouring card or other element.
+   (The tooltip's own z-index is otherwise capped within this context's z:10.)
+   :hover matches here even though the overlay is pointer-events:none, because the
+   hovered button is its descendant. */
+.dparty-overlay:hover {
+    z-index: 214748364;
+}
+
+/* shadcn-like frosted-glass icon button. Both buttons share the same quiet
+   neutral surface; the party button is distinguished only by a brand-colored
+   icon (a loud red fill was too prominent over the thumbnails). */
+.dparty-btn {
+    --dp-brand: oklch(0.637 0.237 25.331);
+    --dp-foreground: oklch(0.32 0 0);
+    --dp-ring: oklch(0.637 0.237 25.331);
+
+    pointer-events: auto;
+    box-sizing: border-box;
+    /* Reset native <button> chrome (we render a custom surface below). */
+    appearance: none;
+    -webkit-appearance: none;
+    font: inherit;
+    /* Anchor for the tooltip pseudo-elements (otherwise they position against
+       the overlay and end up mislocated). */
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* Fixed square. !important + flex:none defeats dアニメストア's own anchor
+       height rules and flexbox stretch, which otherwise stretch us vertically. */
+    flex: 0 0 auto;
+    width: 34px !important;
+    height: 34px !important;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 10px;
+    color: var(--dp-foreground);
+    background-color: rgba(255, 255, 255, 0.82);
+    backdrop-filter: blur(8px) saturate(1.4);
+    -webkit-backdrop-filter: blur(8px) saturate(1.4);
+    cursor: pointer;
+    text-decoration: none !important;
+    user-select: none;
+    box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.08),
+        0 4px 12px rgba(0, 0, 0, 0.1);
+    transition:
+        transform 0.15s ease,
+        box-shadow 0.15s ease,
+        background-color 0.15s ease,
+        color 0.15s ease;
+}
+
+/* Fill the button so the icon glyph is truly centered — material-icons' own
+   font metrics otherwise push the glyph toward the top. */
+.dparty-btn .material-icons {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 20px;
+    line-height: 1;
+}
+
+/* Explicit hover/focus/active states. The `:hover`/`:focus` selectors raise
+   specificity above dアニメストア's own `a:hover { text-decoration: underline }`
+   (the !important on the base rule alone loses to their higher specificity). */
+.dparty-btn:hover,
+.dparty-btn:focus,
+.dparty-btn:active {
+    text-decoration: none !important;
+}
+
+.dparty-btn:hover {
+    transform: translateY(-1px);
+    background-color: rgba(255, 255, 255, 0.95);
+    box-shadow:
+        0 2px 4px rgba(0, 0, 0, 0.1),
+        0 8px 18px rgba(0, 0, 0, 0.14);
+}
+
+.dparty-btn:active {
+    transform: translateY(0);
+    box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.08),
+        0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.dparty-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--dp-ring);
+}
+
+/* Both buttons share the same neutral (dark) icon color; they are distinguished
+   only by their glyph (play vs groups). */
+
+/* The extra "別タブで視聴する" button in the detail modal. It is absolutely
+   positioned just OUTSIDE the right edge of 視聴する (#streamingQuality), so it
+   sits beside 視聴する without overlapping it and 視聴する is never reparented or
+   resized (it shares no width with the button, unlike a flex sibling, and an
+   inline-flex wrapper had collapsed it to its text width). */
+#streamingQuality {
+    position: relative;
+}
+
+.dparty-modal-open {
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    transform: translateY(-50%);
+    margin-left: 10px;
+    z-index: 5;
+}
+
+/* Keep the -50% vertical centering on hover/active. The shared .dparty-btn
+   hover/active transforms (translateY(-1px)/translateY(0)) would otherwise drop
+   this absolutely-centered button by ~half its height. We keep a small downward
+   "press" of ~8px — about half of that unintended drop. */
+.dparty-modal-open:hover,
+.dparty-modal-open:active {
+    transform: translateY(calc(-50% + 8px));
+}
+
+.dparty-hidden {
+    display: none !important;
+}
+
+/* Tooltip. Rendered at document.body level (see showTooltip in the content
+   script) and positioned with position:fixed, so it is NOT clipped by the Swiper
+   carousel's overflow:hidden (which cut off the right-most card's tooltip) and
+   always paints on top. The JS sets left/top to the button's viewport rect; the
+   transform shifts the bubble to sit centered just above the button. */
+.dparty-tooltip {
+    position: fixed;
+    transform: translate(-50%, calc(-100% - 8px));
     font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
     font-size: 12px;
     line-height: 1.4;
@@ -38,35 +186,21 @@
 }
 
 /* 吹き出しの矢印 */
-.play-btn[data-tooltip]::before,
-.popper-btn[data-tooltip]::before {
+.dparty-tooltip::after {
     content: "";
     position: absolute;
-    bottom: 100%;
+    top: 100%;
     left: 50%;
     transform: translateX(-50%);
     border: 5px solid transparent;
     border-top-color: rgba(0, 0, 0, 0.85);
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transition: opacity 0.15s ease;
-    z-index: 2147483647;
 }
 
-.play-btn[data-tooltip]:hover::after,
-.popper-btn[data-tooltip]:hover::after,
-.play-btn[data-tooltip]:hover::before,
-.popper-btn[data-tooltip]:hover::before {
+.dparty-tooltip--visible {
     opacity: 1;
     visibility: visible;
 }
 
-section.clearfix {
-    display: flex;
-    width: 100%!important;
-}
-
-.watched_episode{
+.watched_episode {
     background-color: #f8f8f8;
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -40,10 +40,12 @@
     },
     {
       "matches": [
-        "https://animestore.docomo.ne.jp/animestore/ci_pc?*",
-        "https://animestore.docomo.ne.jp/animestore/tp_pc*",
-        "https://anime.dmkt-sp.jp/animestore/ci_pc?*",
-        "https://anime.dmkt-sp.jp/animestore/tp_pc*"
+        "https://animestore.docomo.ne.jp/animestore/*",
+        "https://anime.dmkt-sp.jp/animestore/*"
+      ],
+      "exclude_matches": [
+        "https://animestore.docomo.ne.jp/animestore/sc_d_pc?*",
+        "https://anime.dmkt-sp.jp/animestore/sc_d_pc?*"
       ],
       "js": [
         "js/content-store.js"

--- a/src/presentation/content/store/index.ts
+++ b/src/presentation/content/store/index.ts
@@ -1,9 +1,16 @@
-import { makeFontFace } from "../dom/utils";
+import { getParam, makeFontFace } from "../dom/utils";
+import { ChromeStorageSettingsRepository } from "@/infrastructure/storage/ChromeStorageSettingsRepository";
+import { DEFAULT_SETTINGS, type Settings } from "@/domain/settings";
 
 /**
  * Content script for the dアニメストア episode-list pages (ci_pc / tp_pc).
  * Adds "open in another tab" (play) and "create party" (popper) icons to each
  * episode.
+ *
+ * It also decorates the episode detail modal (opened on ci_pc): depending on the
+ * "動画は全て別タブで開く" (autoAnotherTab) setting, either the page's own 視聴する
+ * button is hijacked to open the player in a new tab, or an extra "別タブで開く"
+ * icon button is shown next to it.
  *
  * Ported from the original store.js. Robustness fixes over the original:
  *  - content scripts run at `document_idle`, frequently *after* `window.load`
@@ -15,19 +22,53 @@ import { makeFontFace } from "../dom/utils";
  * The original also injected an inline <script> into the page to strip dアニメ
  * ストア's own click handlers; that violated the page CSP (inline scripts are
  * blocked) and never worked from the isolated world, so it has been removed.
+ *
+ * Layout: the buttons are added as an absolutely-positioned overlay on top of
+ * the card (see public/css/style.css). We deliberately do NOT restructure
+ * dアニメストア's native list layout (no flexbox / width overrides on the
+ * <section>/<a>). The previous approach shrank the real link to 80% and made
+ * the icons flex siblings at height:100%, which stretched the row and drew a
+ * line between the thumbnail and its frame — worse when an episode carried a
+ * NEW tag (`optionIconContainer`) that changed the card height.
  */
 
 const DECORATED_ATTR = "data-dparty-decorated";
+const MODAL_DECORATED_ATTR = "data-dparty-modal-decorated";
+const PLAYLINK_ATTR = "data-dparty-playlink";
+
+const settingsRepo = new ChromeStorageSettingsRepository();
+/**
+ * Cached settings, kept in sync with chrome.storage. The 視聴する click handler
+ * reads this live, so toggling the setting takes effect without reloading; the
+ * extra button's visibility is refreshed on each `decorate()`.
+ */
+let currentSettings: Settings = DEFAULT_SETTINGS;
 
 makeFontFace();
 ready(main);
+void loadSettings();
 
 function main(): void {
-  decorateEpisodes();
-  // Re-decorate as the (dynamically loaded) list grows. Idempotent: already
-  // decorated items are skipped, and the icons we add don't match the filter.
-  const observer = new MutationObserver(() => decorateEpisodes());
+  decorate();
+  // Re-decorate as the (dynamically loaded) list grows and as the detail modal
+  // opens/navigates. Idempotent: already decorated nodes are skipped.
+  const observer = new MutationObserver(() => decorate());
   observer.observe(document.body, { childList: true, subtree: true });
+}
+
+function decorate(): void {
+  decorateEpisodes();
+  decorateModal();
+  decoratePlaylinks();
+}
+
+async function loadSettings(): Promise<void> {
+  currentSettings = await settingsRepo.getAll();
+  decorate();
+  settingsRepo.onChange((next) => {
+    currentSettings = next;
+    decorate();
+  });
 }
 
 /** Add the play/popper icons to every not-yet-decorated episode link. */
@@ -45,24 +86,240 @@ function decorateEpisodes(): void {
       item.parentElement?.classList.add("watched_episode");
     }
 
-    const playIcon = document.createElement("a");
-    playIcon.textContent = "play_circle_filled";
-    playIcon.setAttribute("class", "material-icons play-btn");
-    playIcon.setAttribute("target", "_blank");
-    playIcon.setAttribute("data-tooltip", "別タブで再生");
-    playIcon.setAttribute("aria-label", "別タブで再生");
-    playIcon.setAttribute("href", "sc_d_pc?partId=" + partId);
-    item.parentElement?.appendChild(playIcon);
-
-    const popperIcon = document.createElement("a");
-    popperIcon.textContent = "groups";
-    popperIcon.setAttribute("data-tooltip", "パーティールームを作成して同時視聴");
-    popperIcon.setAttribute("aria-label", "パーティールームを作成して同時視聴");
-    popperIcon.setAttribute("class", "material-icons popper-btn");
-    popperIcon.setAttribute("target", "_blank");
-    popperIcon.setAttribute("href", "sc_d_pc?partId=" + partId + "&party=create");
-    item.parentElement?.appendChild(popperIcon);
+    const overlay = document.createElement("div");
+    overlay.className = "dparty-overlay";
+    overlay.appendChild(
+      createButton({
+        icon: "play_circle_filled",
+        variant: "play",
+        tooltip: "別タブで再生",
+        href: "sc_d_pc?partId=" + partId,
+      }),
+    );
+    overlay.appendChild(
+      createButton({
+        icon: "groups",
+        variant: "party",
+        tooltip: "パーティールームを作成",
+        href: "sc_d_pc?partId=" + partId + "&party=create",
+      }),
+    );
+    item.parentElement?.appendChild(overlay);
   }
+}
+
+/**
+ * Build a single shadcn-like icon button.
+ *
+ * We deliberately use a <button>, not an <a>: dアニメストア styles `.itemModule
+ * .list a` directly (hover underline, `position`, its own click handlers), and
+ * those rules outrank ours, so as an <a> the underline showed through and our
+ * `position: relative` (needed to anchor the tooltip) was overridden. A <button>
+ * matches none of those `a` selectors, so all of it goes away at once. Navigation
+ * is done by us via window.open below, so we don't need anchor semantics.
+ */
+function createButton(opts: {
+  icon: string;
+  variant: "play" | "party";
+  tooltip: string;
+  href: string;
+}): HTMLButtonElement {
+  // Resolve the relative href against the current page so window.open gets an
+  // absolute URL (a <button> can't resolve it for us like an <a> would).
+  const url = new URL(opts.href, window.location.href).href;
+  return iconButton({
+    icon: opts.icon,
+    className: `dparty-btn dparty-btn--${opts.variant}`,
+    tooltip: opts.tooltip,
+    onClick: () => window.open(url, "_blank", "noopener"),
+  });
+}
+
+/**
+ * Build a shadcn-like icon <button>.
+ *
+ * We deliberately use a <button>, not an <a>: dアニメストア styles `.itemModule
+ * .list a` directly (hover underline, `position`, its own click handlers), and
+ * those rules outrank ours, so as an <a> the underline showed through and our
+ * `position: relative` (needed to anchor the tooltip) was overridden. A <button>
+ * matches none of those `a` selectors. Navigation is done by us in `onClick`, so
+ * we don't need anchor semantics.
+ */
+function iconButton(opts: {
+  icon: string;
+  className: string;
+  tooltip: string;
+  onClick: () => void;
+}): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = opts.className;
+  button.setAttribute("aria-label", opts.tooltip);
+
+  // dアニメストア attaches its own click handlers; run on the capture phase and
+  // stop the event before the page's handlers see it, so a single click acts.
+  button.addEventListener(
+    "click",
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      hideTooltip();
+      opts.onClick();
+    },
+    true,
+  );
+
+  // Tooltip is rendered at document.body level (see showTooltip): a CSS pseudo
+  // tooltip is clipped by the Swiper container's overflow:hidden (the right-most
+  // card's tooltip gets cut off at the carousel edge) and can't escape via
+  // z-index, since the swiper-wrapper's transform also traps position:fixed.
+  button.addEventListener("mouseenter", () => showTooltip(button, opts.tooltip));
+  button.addEventListener("mouseleave", hideTooltip);
+  button.addEventListener("focus", () => showTooltip(button, opts.tooltip));
+  button.addEventListener("blur", hideTooltip);
+
+  // The icon font lives in an inner span so material-icons' font/size styling
+  // can't leak onto the button box (and break its layout).
+  const glyph = document.createElement("span");
+  glyph.className = "material-icons";
+  glyph.setAttribute("aria-hidden", "true");
+  glyph.textContent = opts.icon;
+  button.appendChild(glyph);
+
+  return button;
+}
+
+/**
+ * A single tooltip element shared by every injected button, appended to
+ * document.body so it is never clipped by the Swiper carousel's overflow:hidden
+ * and always paints on top. Positioned with position:fixed using the button's
+ * viewport rect.
+ */
+let tooltipEl: HTMLDivElement | null = null;
+
+function showTooltip(target: HTMLElement, text: string): void {
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "dparty-tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  tooltipEl.textContent = text;
+  const rect = target.getBoundingClientRect();
+  // Anchor the bubble's bottom-center 8px above the button (offset via CSS transform).
+  tooltipEl.style.left = `${rect.left + rect.width / 2}px`;
+  tooltipEl.style.top = `${rect.top}px`;
+  tooltipEl.classList.add("dparty-tooltip--visible");
+}
+
+function hideTooltip(): void {
+  tooltipEl?.classList.remove("dparty-tooltip--visible");
+}
+
+/**
+ * Decorate the episode detail modal's 視聴する button (opened on ci_pc).
+ *
+ * - autoAnotherTab ON  : clicking 視聴する opens the player in a new tab instead
+ *   of playing inline.
+ * - autoAnotherTab OFF : 視聴する keeps its native behavior and an extra
+ *   "別タブで視聴する" icon button overlays its right edge.
+ *
+ * We do NOT reparent or resize 視聴する. The extra button is appended INSIDE the
+ * 視聴する pill and absolutely positioned just past its right edge (see css). This
+ * matters: #streamingQuality is a flex "quality list", so a button placed as its
+ * direct child counts as a second list item and the page's rules shrink 視聴する
+ * to half width. Nested in 視聴する, it is out of that flex flow, so 視聴する keeps
+ * its native centered width and our button sits in the empty space beside it.
+ * The 視聴する handler reads the setting live, and the extra button's visibility
+ * is refreshed every run, so toggling the setting takes effect immediately.
+ */
+function decorateModal(): void {
+  const quality = document.querySelector("#streamingQuality");
+  const watchButton = quality?.querySelector<HTMLElement>("a.normal");
+  if (!quality || !watchButton) return;
+
+  if (!quality.hasAttribute(MODAL_DECORATED_ATTR)) {
+    quality.setAttribute(MODAL_DECORATED_ATTR, "1");
+
+    // Hijack 視聴する only while "open all in new tab" is on (checked live).
+    watchButton.addEventListener(
+      "click",
+      (event) => {
+        if (!currentSettings.autoAnotherTab) return; // keep native inline play
+        if (!openPlayerInNewTab()) return;
+        event.preventDefault();
+        event.stopPropagation();
+      },
+      true,
+    );
+
+    // Extra button for the OFF case, anchored to 視聴する's right edge (CSS).
+    const openButton = iconButton({
+      icon: "open_in_new",
+      className: "dparty-btn dparty-btn--play dparty-modal-open",
+      tooltip: "別タブで視聴する",
+      onClick: () => openPlayerInNewTab(),
+    });
+    // Anchor for the absolutely-positioned button; relative with no offsets does
+    // not move or resize 視聴する itself.
+    watchButton.style.position = "relative";
+    watchButton.appendChild(openButton);
+  }
+
+  const openButton = quality.querySelector(".dparty-modal-open");
+  openButton?.classList.toggle("dparty-hidden", currentSettings.autoAnotherTab);
+}
+
+/**
+ * Hijack the "今すぐ視聴する" links in the hover popups shown across dアニメストア
+ * (top page, genre/series lists, etc.): when "動画は全て別タブで開く" is on, open
+ * the player in a new tab instead of playing inline. Otherwise leave them alone.
+ * These links carry the partId directly in `data-partid`.
+ */
+function decoratePlaylinks(): void {
+  const links = document.querySelectorAll<HTMLElement>("a.playlink[data-partid]");
+
+  for (const link of Array.from(links)) {
+    if (link.hasAttribute(PLAYLINK_ATTR)) continue;
+    link.setAttribute(PLAYLINK_ATTR, "1");
+
+    link.addEventListener(
+      "click",
+      (event) => {
+        if (!currentSettings.autoAnotherTab) return; // keep native inline play
+        const partId = link.getAttribute("data-partid");
+        if (!partId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const url = new URL("sc_d_pc?partId=" + partId, window.location.href).href;
+        window.open(url, "_blank", "noopener");
+      },
+      true,
+    );
+  }
+}
+
+/**
+ * Open the currently-shown episode in the player in a new tab. Returns false if
+ * the partId could not be resolved (so callers can fall back to native behavior).
+ */
+function openPlayerInNewTab(): boolean {
+  const partId = currentPartId();
+  if (!partId) return false;
+  const url = new URL("sc_d_pc?partId=" + partId, window.location.href).href;
+  window.open(url, "_blank", "noopener");
+  return true;
+}
+
+/**
+ * The partId of the episode currently shown in the modal. Read from the modal
+ * thumbnail's filename (`.../28724001_1_1.png`) so it stays correct as the user
+ * pages prev/next; falls back to the page URL's partId.
+ */
+function currentPartId(): string | null {
+  const img = document.querySelector<HTMLImageElement>("#modalThumbImg");
+  const src = img?.getAttribute("src") ?? img?.getAttribute("data-src") ?? "";
+  const match = src.match(/\/(\d+)_\d+_\d+\.(?:png|jpe?g)/i);
+  return match ? match[1] : getParam("partId");
 }
 
 /** Run `fn` now if the document has finished loading, otherwise on `load`. */

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -74,8 +74,8 @@ const SYNC_TOGGLES: Toggle[] = [
 const UTILITY_TOGGLES: Toggle[] = [
   {
     key: "autoAnotherTab",
-    label: "別タブで自動再生",
-    description: "動画を新しいタブで開く",
+    label: "動画は全て別タブで開く",
+    description: "再生を常に新しいタブで開く",
     icon: ExternalLink,
   },
   {


### PR DESCRIPTION
## 概要
dアニメストアのエピソード一覧・詳細モーダル・各ページのホバーポップアップに対し、d-party のボタン/挙動を刷新しました。

## 変更点
### エピソード一覧 (ci_pc / tp_pc)
- ネイティブのリストレイアウトを**崩さないオーバーレイ方式**に変更（サムネと枠の間の線、NEWタグ時の崩れを解消）。
- shadcn 風のフロストガラス調アイコンボタン。`<a>` ではなく `<button>` 化し、ページ側 `.itemModule.list a` の hover下線・position 上書き・クリック妨害を回避。
- ボタンを**下付き**配置にしてタイトルとの衝突を回避。**シングルクリック**で遷移。
- tooltip を `document.body` 直下の `position:fixed` 要素に変更し、Swiper の `overflow:hidden` / `transform` による**クリップ・最背面化**を解消（右端カードでも切れない）。

### 詳細モーダル (ci_pc)
- 設定「動画は全て別タブで開く」**ON**: 「視聴する」を別タブで開く。
- **OFF**: 「視聴する」の右隣に「別タブで視聴する」ボタンを追加（**視聴する自体の幅は変更しない**）。
- partId はサムネ画像名から取得（prev/next 追従）、URL をフォールバック。

### ホバーポップアップ「今すぐ視聴する」
- `a.playlink[data-partid]` を設定 ON 時のみ別タブで開く。対象ページを `…/animestore/*` 全体に拡大し、プレイヤー (`sc_d_pc`) は除外。

### 設定
- ラベル「別タブで自動再生」→「**動画は全て別タブで開く**」（ストレージキーは不変）。

## 確認
- `pnpm typecheck` / `pnpm lint` / `pnpm build` 通過。
- DOM 結合は有料の実ページで確認済み（一覧／詳細モーダル／tp_pc ポップアップ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)