### PR TITLE
feat(playlinks): 再生ウィジェット (続きから視聴する) も別タブで開く対象に追加

### DIFF
--- a/src/presentation/content/store/index.ts
+++ b/src/presentation/content/store/index.ts
@@ -270,13 +270,18 @@ function decorateModal(): void {
 }
 
 /**
- * Hijack the "今すぐ視聴する" links in the hover popups shown across dアニメストア
- * (top page, genre/series lists, etc.): when "動画は全て別タブで開く" is on, open
- * the player in a new tab instead of playing inline. Otherwise leave them alone.
- * These links carry the partId directly in `data-partid`.
+ * Hijack the inline-play links scattered across dアニメストア: when "動画は全て別タブ
+ * で開く" is on, open the player in a new tab instead of playing inline. Otherwise
+ * leave them alone. These all carry the partId directly in `data-partid`:
+ *  - `a.playlink`        : the "今すぐ視聴する" links in hover popups (top page,
+ *    genre/series lists, etc.);
+ *  - `a.directPlayReady` : the "視聴中の作品 / 続きから視聴する" resume widget on the
+ *    top page (tp_pc) — both its 続きから視聴する button and its thumbnail link.
  */
 function decoratePlaylinks(): void {
-  const links = document.querySelectorAll<HTMLElement>("a.playlink[data-partid]");
+  const links = document.querySelectorAll<HTMLElement>(
+    "a.playlink[data-partid], a.directPlayReady[data-partid]",
+  );
 
   for (const link of Array.from(links)) {
     if (link.hasAttribute(PLAYLINK_ATTR)) continue;


### PR DESCRIPTION
## 概要

dアニメストア トップページ (tp_pc) の「視聴中の作品 / 続きから視聴する」再生ウィジェット (`a.directPlayReady[data-partid]`) を、`decoratePlaylinks` のフック対象に追加しました。

これにより、設定「動画は全て別タブで開く」が ON のとき、ホバーポップアップの `a.playlink` だけでなく、続きから視聴ウィジェットの「続きから視聴する」ボタン・サムネイルリンクも新しいタブでプレイヤーを開くようになります。

## 変更点

- `src/presentation/content/store/index.ts`:
  - クエリセレクタを `a.playlink[data-partid]` から `a.playlink[data-partid], a.directPlayReady[data-partid]` に拡張
  - JSDoc を更新し、対象セレクタとその用途を明記

## 確認

- 設定 OFF: 既存挙動のまま (リンクはそのまま)
- 設定 ON: ホバーポップアップ / 続きから視聴ウィジェットの両方が別タブで開く

> 注: content script の最終確認は有料の dアニメストア実ページが必要。ロジック差分は 1 セレクタ追加のみ。