### PR TITLE
fix(release): skip bump commit when version unchanged and force-update tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,22 @@ jobs:
 
       - name: Commit and push version bump
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json public/manifest.json
-          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
-          git push origin HEAD:main
+          if git diff --cached --quiet; then
+            echo "version files already at ${{ steps.version.outputs.new_version }}; skipping bump commit"
+          else
+            git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
+            git push origin HEAD:main
+          fi
+
+      - name: Force-update release tag
+        run: |
+          set -euo pipefail
+          git tag -f "${{ steps.version.outputs.new_version }}"
+          git push origin "refs/tags/${{ steps.version.outputs.new_version }}" --force
 
       - name: Generate API client
         run: pnpm api:generate


### PR DESCRIPTION
## What

`release` ワークフローの `Bump version and commit` ステップが、対象ファイルに version の差分が無いとき `git commit` の失敗で run 全体を落とす問題を修正します。

- bump 用の `git commit` / `git push` を「ステージに差分があれば実行、無ければスキップして次のステップに進む」に変更
- リリースタグを `git tag -f` + `git push --force` で **HEAD に強制再付与** するステップを追加（ルートと各サブモジュールでタグずれが起きた場合の自己修復用）

## Why

直近の root `release` run でこの問題が連鎖し、サブモジュール側で bump が完了しているのに root 側ではタグが進まず、再実行しても全サブモジュールが `nothing to commit` で落ち続ける状態になっていました。本変更で v2.6.1 のような重複実行や、root とサブモジュールの version ズレ復旧時にも release ワークフローが冪等に成功するようにします。

## How tested

YAML 編集のみ。実走は次回の release ワークフロー起動で確認します。