### PR TITLE
feat: ユーザーアイコン機能（react-icons / FA6）を追加

### DIFF
--- a/src/application/RoomSession.ts
+++ b/src/application/RoomSession.ts
@@ -1,9 +1,5 @@
 import { describeOperation } from "@/domain/history";
-import type {
-  IncomingMessage,
-  OutgoingMessage,
-  User,
-} from "@/domain/protocol";
+import type { IncomingMessage, OutgoingMessage, User } from "@/domain/protocol";
 import type { ReactionType } from "@/domain/reactions";
 import type { PartyWebSocketClient } from "@/infrastructure/ws/PartyWebSocketClient";
 import { ANIMESTORE_REDIRECT_ENDPOINT } from "@/infrastructure/env";
@@ -90,6 +86,7 @@ export class RoomSession {
       this.send({
         action: "create",
         user_name: this.userName,
+        user_icon: this.userIcon,
         part_id: partId,
         title,
         request_id: now(),
@@ -108,6 +105,7 @@ export class RoomSession {
       this.send({
         action: "join",
         user_name: this.userName,
+        user_icon: this.userIcon,
         room_id: roomId,
         request_id: now(),
       });
@@ -238,7 +236,11 @@ export class RoomSession {
   }
 
   sendReaction(reactionType: ReactionType): void {
-    this.send({ action: "reaction", reaction_type: reactionType, request_id: now() });
+    this.send({
+      action: "reaction",
+      reaction_type: reactionType,
+      request_id: now(),
+    });
     this.deps.stats.reactionSent(reactionType);
   }
 
@@ -373,6 +375,7 @@ export class RoomSession {
           icon: "join",
           label: `『${message.user.user_name}』さんが入室`,
           user: message.user.user_name,
+          userIcon: message.user.user_icon,
         });
         break;
       case "user_list":
@@ -385,6 +388,7 @@ export class RoomSession {
           icon: "leave",
           label: `『${message.user.user_name}』さんが退室`,
           user: message.user.user_name,
+          userIcon: message.user.user_icon,
         });
         break;
       case "sync_request":
@@ -406,7 +410,11 @@ export class RoomSession {
         }
         break;
       case "operation_notification":
-        this.notifyOperation(message.operation, message.user.user_name);
+        this.notifyOperation(
+          message.operation,
+          message.user.user_name,
+          message.user.user_icon,
+        );
         break;
       case "reaction":
         if (!settings.current().hideReaction) {
@@ -435,7 +443,11 @@ export class RoomSession {
 
   // 他の参加者の操作通知 (operation_notification) を受信したとき、トーストと
   // 履歴に「受信」エントリとして表示する。
-  private notifyOperation(operation: string, userName: string): void {
+  private notifyOperation(
+    operation: string,
+    userName: string,
+    userIcon?: string,
+  ): void {
     const meta = describeOperation(operation);
     if (!meta) return;
     this.deps.notifier.info(`『${userName}』さんが${meta.label}`);
@@ -444,6 +456,7 @@ export class RoomSession {
       icon: meta.icon,
       label: meta.label,
       user: userName,
+      userIcon,
     });
   }
 
@@ -467,6 +480,10 @@ export class RoomSession {
 
   private get userName(): string {
     return this.deps.settings.current().userName;
+  }
+
+  private get userIcon(): string {
+    return this.deps.settings.current().userIcon;
   }
 }
 

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,0 +1,23 @@
+import { DEFAULT_USER_ICON, USER_ICONS } from "./userIcons";
+
+/**
+ * Renders a participant's avatar from a stored react-icons (FA6) key, falling
+ * back to the default user icon for missing/unknown keys. Defined at module
+ * scope so call sites can render `<UserAvatar .../>` without resolving an icon
+ * component during their own render (which the lint rules disallow).
+ *
+ * The icon is selected by direct map lookup (a stable reference) rather than via
+ * a function call, mirroring the `HISTORY_ICONS[...]` pattern, so it is not
+ * treated as "creating a component during render".
+ */
+export function UserAvatar({
+  iconKey,
+  className,
+}: {
+  iconKey?: string;
+  className?: string;
+}): React.JSX.Element {
+  const Icon =
+    (iconKey && USER_ICONS[iconKey]) || USER_ICONS[DEFAULT_USER_ICON];
+  return <Icon className={className} aria-hidden />;
+}

--- a/src/components/userIcons.ts
+++ b/src/components/userIcons.ts
@@ -1,0 +1,182 @@
+/**
+ * Curated set of user avatar icons (react-icons / Font Awesome 6).
+ *
+ * The chosen icon is stored as a react-icons key string (e.g. `"FaCat"`) and
+ * sent to the backend on join, mirroring `user_name`. Both the popup picker and
+ * the sidebar (user list / history) resolve the key through this single shared
+ * map, so the content-script bundle only ever pulls in this curated subset
+ * rather than the entire `react-icons/fa6` package.
+ *
+ * Keep keys in lock-step with the backend default: an unknown or missing key
+ * falls back to {@link DEFAULT_USER_ICON} (the plain user outline), which is the
+ * same default the backend assigns to clients that don't send `user_icon`.
+ */
+
+import type { IconType } from "react-icons/lib";
+import {
+  FaAnchor,
+  FaAppleWhole,
+  FaBasketball,
+  FaBicycle,
+  FaBolt,
+  FaBug,
+  FaCamera,
+  FaCar,
+  FaCarrot,
+  FaCat,
+  FaCheese,
+  FaChess,
+  FaCloud,
+  FaCookie,
+  FaCrow,
+  FaCrown,
+  FaDice,
+  FaDog,
+  FaDove,
+  FaDragon,
+  FaFeather,
+  FaFilm,
+  FaFire,
+  FaFish,
+  FaFrog,
+  FaFutbol,
+  FaGamepad,
+  FaGem,
+  FaGhost,
+  FaGuitar,
+  FaHeadphones,
+  FaHeart,
+  FaHippo,
+  FaHorse,
+  FaIceCream,
+  FaKiwiBird,
+  FaLeaf,
+  FaMoon,
+  FaMugHot,
+  FaMusic,
+  FaOtter,
+  FaPalette,
+  FaPaw,
+  FaPizzaSlice,
+  FaPlane,
+  FaRegFaceAngry,
+  FaRegFaceGrinHearts,
+  FaRegFaceGrinStars,
+  FaRegFaceLaugh,
+  FaRegFaceMeh,
+  FaRegFaceSadTear,
+  FaRegFaceSmile,
+  FaRegFaceSurprise,
+  FaRegUser,
+  FaRobot,
+  FaRocket,
+  FaSeedling,
+  FaSkull,
+  FaSnowflake,
+  FaSpider,
+  FaStar,
+  FaSun,
+  FaTree,
+  FaUmbrella,
+  FaUser,
+  FaUserAstronaut,
+  FaUserDoctor,
+  FaUserGraduate,
+  FaUserNinja,
+  FaUserSecret,
+  FaUserTie,
+  FaWorm,
+} from "react-icons/fa6";
+
+/** Default key, kept identical to the backend's default for older clients/data. */
+export const DEFAULT_USER_ICON = "FaRegUser";
+
+/**
+ * The curated, selectable icons keyed by their react-icons name. The first
+ * entry is the default; the order here is the order shown in the picker.
+ */
+export const USER_ICONS: Record<string, IconType> = {
+  // People
+  FaRegUser,
+  FaUser,
+  FaUserAstronaut,
+  FaUserNinja,
+  FaUserSecret,
+  FaUserTie,
+  FaUserGraduate,
+  FaUserDoctor,
+  FaRobot,
+  FaSkull,
+  // Faces
+  FaRegFaceSmile,
+  FaRegFaceLaugh,
+  FaRegFaceGrinStars,
+  FaRegFaceGrinHearts,
+  FaRegFaceSurprise,
+  FaRegFaceMeh,
+  FaRegFaceSadTear,
+  FaRegFaceAngry,
+  // Animals
+  FaCat,
+  FaDog,
+  FaHorse,
+  FaHippo,
+  FaOtter,
+  FaFrog,
+  FaFish,
+  FaCrow,
+  FaDove,
+  FaKiwiBird,
+  FaSpider,
+  FaWorm,
+  FaBug,
+  FaDragon,
+  FaPaw,
+  FaFeather,
+  // Nature & weather
+  FaTree,
+  FaLeaf,
+  FaSeedling,
+  FaFire,
+  FaBolt,
+  FaSnowflake,
+  FaSun,
+  FaMoon,
+  FaCloud,
+  FaUmbrella,
+  // Symbols
+  FaCrown,
+  FaGhost,
+  FaHeart,
+  FaStar,
+  FaGem,
+  // Activities & hobbies
+  FaRocket,
+  FaGamepad,
+  FaDice,
+  FaChess,
+  FaPalette,
+  FaMusic,
+  FaGuitar,
+  FaHeadphones,
+  FaFilm,
+  FaCamera,
+  FaFutbol,
+  FaBasketball,
+  // Travel
+  FaCar,
+  FaPlane,
+  FaBicycle,
+  FaAnchor,
+  // Food
+  FaPizzaSlice,
+  FaIceCream,
+  FaMugHot,
+  FaAppleWhole,
+  FaCarrot,
+  FaCheese,
+  FaCookie,
+};
+
+/** Selectable icon keys, in display order (used by the popup picker). */
+export const USER_ICON_KEYS: string[] = Object.keys(USER_ICONS);

--- a/src/domain/history.ts
+++ b/src/domain/history.ts
@@ -39,6 +39,11 @@ export interface HistoryEntryInput {
    * events. Used both for display and for the participant filter.
    */
   user?: string;
+  /**
+   * The participant's avatar icon (react-icons / FA6 key), shown next to their
+   * name. Optional: missing/unknown keys fall back to the default user icon.
+   */
+  userIcon?: string;
 }
 
 export interface OperationMeta {

--- a/src/domain/protocol.ts
+++ b/src/domain/protocol.ts
@@ -14,6 +14,11 @@ export interface User {
   user_id: string;
   user_name: string;
   /**
+   * 表示アイコン（react-icons / Font Awesome 6 のキー文字列）。
+   * 旧バックエンド互換のため任意（未指定なら既定アイコンにフォールバック）。
+   */
+  user_icon?: string;
+  /**
    * ルームのホスト（オーナー）かどうか。`user_list` で配信される。
    * 旧バックエンド互換のため任意（未指定なら非ホスト扱い）。
    */
@@ -48,6 +53,8 @@ export interface SyncOption {
 export interface CreateRoomMessage {
   action: "create";
   user_name: string;
+  /** 表示アイコン（react-icons / FA6 のキー）。バックエンドは未指定でも受理する。 */
+  user_icon: string;
   part_id: string;
   /**
    * 視聴中アニメのタイトル（ページ DOM から取得）。OGP 表示用にルーム作成時に
@@ -60,6 +67,8 @@ export interface CreateRoomMessage {
 export interface JoinRoomMessage {
   action: "join";
   user_name: string;
+  /** 表示アイコン（react-icons / FA6 のキー）。バックエンドは未指定でも受理する。 */
+  user_icon: string;
   room_id: string;
   request_id: number;
 }

--- a/src/domain/settings.ts
+++ b/src/domain/settings.ts
@@ -12,6 +12,12 @@ export interface Settings {
   hideReactionIcon: boolean;
   selfNotification: boolean;
   userName: string;
+  /**
+   * 表示アイコン。react-icons (Font Awesome 6) のキー文字列（例: "FaCat"）。
+   * ルーム参加時に user_name と同様にバックエンドへ送る。未設定や未知のキーは
+   * 既定の素朴なユーザーアイコンにフォールバックする（UserAvatar が解決）。
+   */
+  userIcon: string;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -22,6 +28,7 @@ export const DEFAULT_SETTINGS: Settings = {
   hideReactionIcon: false,
   selfNotification: false,
   userName: "ユーザー",
+  userIcon: "FaRegUser",
 };
 
 /** Mapping between domain fields and `chrome.storage` keys. */
@@ -33,4 +40,5 @@ export const STORAGE_KEYS = {
   hideReactionIcon: "hide_reaction_icon",
   selfNotification: "self_notification",
   userName: "user_name",
+  userIcon: "user_icon",
 } as const satisfies Record<keyof Settings, string>;

--- a/src/infrastructure/storage/ChromeStorageSettingsRepository.ts
+++ b/src/infrastructure/storage/ChromeStorageSettingsRepository.ts
@@ -12,17 +12,39 @@ export class ChromeStorageSettingsRepository {
   async getAll(): Promise<Settings> {
     const stored = await chrome.storage.sync.get(Object.values(STORAGE_KEYS));
     return {
-      autoAnotherTab: bool(stored[STORAGE_KEYS.autoAnotherTab], DEFAULT_SETTINGS.autoAnotherTab),
-      autoUserNameDecision: bool(stored[STORAGE_KEYS.autoUserNameDecision], DEFAULT_SETTINGS.autoUserNameDecision),
-      enablePictureInPicture: bool(stored[STORAGE_KEYS.enablePictureInPicture], DEFAULT_SETTINGS.enablePictureInPicture),
-      hideReaction: bool(stored[STORAGE_KEYS.hideReaction], DEFAULT_SETTINGS.hideReaction),
-      hideReactionIcon: bool(stored[STORAGE_KEYS.hideReactionIcon], DEFAULT_SETTINGS.hideReactionIcon),
-      selfNotification: bool(stored[STORAGE_KEYS.selfNotification], DEFAULT_SETTINGS.selfNotification),
+      autoAnotherTab: bool(
+        stored[STORAGE_KEYS.autoAnotherTab],
+        DEFAULT_SETTINGS.autoAnotherTab,
+      ),
+      autoUserNameDecision: bool(
+        stored[STORAGE_KEYS.autoUserNameDecision],
+        DEFAULT_SETTINGS.autoUserNameDecision,
+      ),
+      enablePictureInPicture: bool(
+        stored[STORAGE_KEYS.enablePictureInPicture],
+        DEFAULT_SETTINGS.enablePictureInPicture,
+      ),
+      hideReaction: bool(
+        stored[STORAGE_KEYS.hideReaction],
+        DEFAULT_SETTINGS.hideReaction,
+      ),
+      hideReactionIcon: bool(
+        stored[STORAGE_KEYS.hideReactionIcon],
+        DEFAULT_SETTINGS.hideReactionIcon,
+      ),
+      selfNotification: bool(
+        stored[STORAGE_KEYS.selfNotification],
+        DEFAULT_SETTINGS.selfNotification,
+      ),
       userName: str(stored[STORAGE_KEYS.userName], DEFAULT_SETTINGS.userName),
+      userIcon: str(stored[STORAGE_KEYS.userIcon], DEFAULT_SETTINGS.userIcon),
     };
   }
 
-  async set<K extends keyof Settings>(key: K, value: Settings[K]): Promise<void> {
+  async set<K extends keyof Settings>(
+    key: K,
+    value: Settings[K],
+  ): Promise<void> {
     await chrome.storage.sync.set({ [STORAGE_KEYS[key]]: value });
   }
 

--- a/src/presentation/content/party/react/Sidebar.stories.tsx
+++ b/src/presentation/content/party/react/Sidebar.stories.tsx
@@ -6,12 +6,14 @@ import { Sidebar } from "./Sidebar";
 import { SidebarStore } from "./sidebarStore";
 
 const SAMPLE_USERS: User[] = [
-  { user_id: "1", user_name: "たかし", is_host: true },
-  { user_id: "2", user_name: "はなこ" },
+  { user_id: "1", user_name: "たかし", user_icon: "FaCat", is_host: true },
+  { user_id: "2", user_name: "はなこ", user_icon: "FaUserNinja" },
+  // user_icon を持たない旧バックエンド互換のユーザー（既定アイコンにフォールバック）。
   { user_id: "3", user_name: "AnonymousUser" },
 ];
 
-const SAMPLE_URL = "http://localhost/anime-store/lobby/4f1c2e9a-1234-4abc-9def-0123456789ab";
+const SAMPLE_URL =
+  "http://localhost/anime-store/lobby/4f1c2e9a-1234-4abc-9def-0123456789ab";
 const SAMPLE_TITLE = "Dr.STONE SCIENCE FUTURE - 第1話 - RYUSUI VS. SENKU";
 
 function frame(store: SidebarStore) {
@@ -68,12 +70,17 @@ export const HistoryTab: Story = {
     store.setMode("join");
     store.setJoined(true);
     store.updateUsers(SAMPLE_USERS);
-    store.addHistory({ direction: "system", icon: "party", label: "ルームを作成しました" });
+    store.addHistory({
+      direction: "system",
+      icon: "party",
+      label: "ルームを作成しました",
+    });
     store.addHistory({
       direction: "system",
       icon: "join",
       label: "『たかし』さんが入室",
       user: "たかし",
+      userIcon: "FaCat",
     });
     store.addHistory({ direction: "sent", icon: "play", label: "再生" });
     store.addHistory({
@@ -81,19 +88,26 @@ export const HistoryTab: Story = {
       icon: "pause",
       label: "停止",
       user: "たかし",
+      userIcon: "FaCat",
     });
     store.addHistory({
       direction: "received",
       icon: "rate",
       label: "×1.5 倍速",
       user: "はなこ",
+      userIcon: "FaUserNinja",
     });
-    store.addHistory({ direction: "system", icon: "sync", label: "再生状況をホストにシンクしました" });
+    store.addHistory({
+      direction: "system",
+      icon: "sync",
+      label: "再生状況をホストにシンクしました",
+    });
     store.addHistory({
       direction: "system",
       icon: "join",
       label: "『はなこ』さんが入室",
       user: "はなこ",
+      userIcon: "FaUserNinja",
     });
     store.setActiveTab("history");
     return frame(store);

--- a/src/presentation/content/party/react/sidebar/HistoryPanel.tsx
+++ b/src/presentation/content/party/react/sidebar/HistoryPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
+import { UserAvatar } from "@/components/UserAvatar";
 import type { HistoryIcon } from "@/domain/history";
 import { cn } from "@/lib/utils";
 
@@ -47,7 +48,11 @@ const SELF_FILTER = "__self__";
 /** Vertical gap between rows (`gap-0.5` = 2px), needed for the fit calculation. */
 const ROW_GAP_PX = 2;
 
-export function HistoryPanel({ state }: { state: SidebarState }): React.JSX.Element {
+export function HistoryPanel({
+  state,
+}: {
+  state: SidebarState;
+}): React.JSX.Element {
   const [filter, setFilter] = useState<string>(ALL_FILTER);
   const [page, setPage] = useState(0);
   const [perPage, setPerPage] = useState(8);
@@ -93,7 +98,9 @@ export function HistoryPanel({ state }: { state: SidebarState }): React.JSX.Elem
     if (!row || containerHeight <= 0) return;
     const rowHeight = row.getBoundingClientRect().height;
     if (rowHeight <= 0) return;
-    const fit = Math.floor((containerHeight + ROW_GAP_PX) / (rowHeight + ROW_GAP_PX));
+    const fit = Math.floor(
+      (containerHeight + ROW_GAP_PX) / (rowHeight + ROW_GAP_PX),
+    );
     setPerPage(Math.max(1, fit));
   }, []);
 
@@ -236,12 +243,19 @@ function HistoryRow({ entry }: { entry: HistoryEntry }): React.JSX.Element {
       </time>
       <div className="flex min-w-0 flex-1 items-center gap-1.5">
         {entry.direction === "received" && entry.user && (
-          <span className="max-w-[5.5rem] shrink-0 truncate text-xs font-semibold text-foreground">
-            {entry.user}
+          <span className="flex max-w-[5.5rem] shrink-0 items-center gap-1 text-xs font-semibold text-foreground">
+            <UserAvatar
+              iconKey={entry.userIcon}
+              className="size-3 shrink-0 text-red-600"
+            />
+            <span className="truncate">{entry.user}</span>
           </span>
         )}
         {!isSystem && (
-          <OpIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <OpIcon
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
         )}
         <span className="truncate text-xs text-foreground">{entry.label}</span>
       </div>

--- a/src/presentation/content/party/react/sidebar/panels.tsx
+++ b/src/presentation/content/party/react/sidebar/panels.tsx
@@ -1,6 +1,7 @@
-import { Crown, LogOut, PartyPopper, Trash2, UserRound } from "lucide-react";
+import { Crown, LogOut, PartyPopper, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { UserAvatar } from "@/components/UserAvatar";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -52,13 +53,19 @@ export function CreatePanel({
   );
 }
 
-export function UsersPanel({ state }: { state: SidebarState }): React.JSX.Element {
+export function UsersPanel({
+  state,
+}: {
+  state: SidebarState;
+}): React.JSX.Element {
   if (state.users.length === 0) {
     return <EmptyHint text="参加者はいません" />;
   }
   return (
     <div className="px-1">
-      <p className="mb-2 text-xs text-muted-foreground">{state.users.length}人が参加中</p>
+      <p className="mb-2 text-xs text-muted-foreground">
+        {state.users.length}人が参加中
+      </p>
       <ul className="flex flex-col gap-1">
         {state.users.map((user) => {
           const isSelf = user.user_id === state.selfUserId;
@@ -68,7 +75,10 @@ export function UsersPanel({ state }: { state: SidebarState }): React.JSX.Elemen
               key={user.user_id}
               className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/60"
             >
-              <UserRound className="size-4 shrink-0 text-red-600" aria-hidden />
+              <UserAvatar
+                iconKey={user.user_icon}
+                className="size-4 shrink-0 text-red-600"
+              />
               <span className="truncate">{user.user_name}</span>
               {/* you と owner が両方付く場合は you を左、owner を右に並べる。 */}
               {(isSelf || isOwner) && (
@@ -167,7 +177,10 @@ function HoldToDeleteButton({
     // ローカルな再帰関数で rAF ループを回す（自己参照 useCallback は不可のため）。
     const loop = (timestamp: number): void => {
       if (startRef.current === null) startRef.current = timestamp;
-      const ratio = Math.min(1, (timestamp - startRef.current) / DELETE_HOLD_MS);
+      const ratio = Math.min(
+        1,
+        (timestamp - startRef.current) / DELETE_HOLD_MS,
+      );
       setProgress(ratio);
       if (ratio >= 1) {
         rafRef.current = null;
@@ -222,6 +235,8 @@ function HoldToDeleteButton({
 
 export function EmptyHint({ text }: { text: string }): React.JSX.Element {
   return (
-    <p className="px-2 py-6 text-center text-xs text-muted-foreground">{text}</p>
+    <p className="px-2 py-6 text-center text-xs text-muted-foreground">
+      {text}
+    </p>
   );
 }

--- a/src/presentation/popup/IconPicker.tsx
+++ b/src/presentation/popup/IconPicker.tsx
@@ -1,0 +1,55 @@
+import { Check } from "lucide-react";
+
+import { UserAvatar } from "@/components/UserAvatar";
+import { USER_ICON_KEYS } from "@/components/userIcons";
+import { cn } from "@/lib/utils";
+
+/**
+ * Grid of selectable avatar icons (curated react-icons / FA6 set). The selected
+ * key is highlighted; clicking one calls {@link onChange} with its key. The
+ * parent persists the choice to settings (`userIcon`).
+ */
+export function IconPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (key: string) => void;
+}): React.JSX.Element {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="表示アイコンを選択"
+      className="grid max-h-44 grid-cols-8 gap-1 overflow-y-auto rounded-lg border bg-muted/30 p-2"
+    >
+      {USER_ICON_KEYS.map((key) => {
+        const selected = key === value;
+        return (
+          <button
+            key={key}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={key}
+            title={key}
+            onClick={() => onChange(key)}
+            className={cn(
+              "relative flex aspect-square items-center justify-center rounded-md transition-colors",
+              selected
+                ? "bg-red-600 text-white"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <UserAvatar iconKey={key} className="size-4" />
+            {selected && (
+              <Check
+                className="absolute -right-0.5 -top-0.5 size-3 rounded-full bg-white text-red-600"
+                aria-hidden
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/presentation/popup/PopupApp.tsx
+++ b/src/presentation/popup/PopupApp.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { UserAvatar } from "@/components/UserAvatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,11 +27,12 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { type Settings } from "@/domain/settings";
 
+import { IconPicker } from "./IconPicker";
 import { InfoPanel } from "./InfoPanel";
 import { PersonalStatsPanel } from "./PersonalStatsPanel";
 import { useSettings } from "./useSettings";
 
-type ToggleKey = Exclude<keyof Settings, "userName">;
+type ToggleKey = Exclude<keyof Settings, "userName" | "userIcon">;
 
 interface Toggle {
   key: ToggleKey;
@@ -223,40 +225,57 @@ export function PopupApp(): React.JSX.Element {
                   <h2 className="text-sm font-semibold">ユーザー設定</h2>
                 </div>
                 {editing ? (
-                  <form className="flex flex-col gap-1.5" onSubmit={submitName}>
-                    <Label
-                      htmlFor="user-name"
-                      className="text-xs text-muted-foreground"
-                    >
-                      表示名（15文字以下）
-                    </Label>
-                    <div className="flex items-center gap-2">
-                      <Input
-                        ref={inputRef}
-                        id="user-name"
-                        className="flex-1"
-                        maxLength={15}
-                        placeholder="あなたの名前"
-                        value={draftName}
-                        onChange={(e) => setDraftName(e.target.value)}
-                      />
-                      <Button
-                        type="submit"
-                        size="icon"
-                        variant="ghost"
-                        className="text-red-600 hover:text-red-600"
-                        aria-label="表示名を確定"
+                  // 編集モード: 鉛筆ボタンから入り、表示名とアイコンをまとめて編集する。
+                  // 名前は ✓ で確定、アイコンは選択した時点で即保存する。
+                  <form className="flex flex-col gap-3" onSubmit={submitName}>
+                    <div className="flex flex-col gap-1.5">
+                      <Label
+                        htmlFor="user-name"
+                        className="text-xs text-muted-foreground"
                       >
-                        <Check className="size-5" aria-hidden />
-                      </Button>
+                        表示名（15文字以下）
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          ref={inputRef}
+                          id="user-name"
+                          className="flex-1"
+                          maxLength={15}
+                          placeholder="あなたの名前"
+                          value={draftName}
+                          onChange={(e) => setDraftName(e.target.value)}
+                        />
+                        <Button
+                          type="submit"
+                          size="icon"
+                          variant="ghost"
+                          className="text-red-600 hover:text-red-600"
+                          aria-label="表示名とアイコンを確定"
+                        >
+                          <Check className="size-5" aria-hidden />
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-xs text-muted-foreground">
+                        アイコン
+                      </span>
+                      <IconPicker
+                        value={settings.userIcon}
+                        onChange={(key) => void update("userIcon", key)}
+                      />
                     </div>
                   </form>
                 ) : (
                   <div className="flex flex-col gap-1.5">
                     <span className="text-xs text-muted-foreground">
-                      表示名
+                      表示名・アイコン
                     </span>
                     <div className="flex items-center gap-2">
+                      <UserAvatar
+                        iconKey={settings.userIcon}
+                        className="size-5 shrink-0 text-red-600"
+                      />
                       <p className="flex-1 truncate text-sm font-medium">
                         {settings.userName || (
                           <span className="text-muted-foreground">未設定</span>
@@ -268,7 +287,9 @@ export function PopupApp(): React.JSX.Element {
                         variant="ghost"
                         className="text-muted-foreground hover:text-foreground"
                         onClick={startEditing}
-                        aria-label={saved ? "保存しました" : "表示名を編集"}
+                        aria-label={
+                          saved ? "保存しました" : "表示名とアイコンを編集"
+                        }
                       >
                         {saved ? (
                           <Check className="size-5 text-red-600" aria-hidden />


### PR DESCRIPTION
## 概要
ユーザーが popup の設定からアバターアイコン（Font Awesome 6 のキュレート集合）を選び、表示名と同様にルーム参加時へ `user_icon` としてバックエンドへ送信。ユーザーリストと履歴で表示名の隣にアイコンを表示する。

## UI
- ユーザー設定の鉛筆ボタンを押すと「編集モード」に入り、**表示名の入力とアイコン選択をまとめて**行える。名前は ✓ で確定、アイコンは選択時に即保存。
- 通常表示は `(アイコン) 名前 [✏️]` をコンパクトに表示。

## 後方互換
- `User.user_icon` は optional。未設定／未知キーや旧バックエンドのユーザーは既定アイコンへフォールバック（`UserAvatar`）。
- アイコンは**キュレートした FA6 集合**を共有マップとして持ち、選択 UI（popup）と表示（sidebar）の双方で同じ集合から解決 → content script バンドルを肥大化させない。

## 変更
- `domain/settings`: `userIcon`（既定 `"FaRegUser"`, storage key `user_icon`）
- `domain/protocol`: `User.user_icon?` と `create` / `join` メッセージの `user_icon`
- `components/userIcons` + `components/UserAvatar`: 共有アイコンマップと描画コンポーネント
- `application/RoomSession`: 参加時に `user_icon` を送信、履歴へ `userIcon` を付与
- `popup/IconPicker` + `PopupApp`: 選択 UI（編集モードに統合）
- sidebar `UsersPanel` / `HistoryPanel`: アバター表示
- `Sidebar.stories`: モックに `user_icon` を付与（フォールバック例含む）

## 動作確認
- `pnpm typecheck` / `lint` / `build` / `build-storybook` すべて pass
- `prettier --write`（PR 対象ファイル）適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)