### PR TITLE
feat(sidebar): healthcheck on first open; maintenance badge on failure

### DIFF
--- a/src/domain/connectionStatus.ts
+++ b/src/domain/connectionStatus.ts
@@ -1,9 +1,11 @@
 /**
  * Connection state of the party WebSocket.
  *
- * `idle`      — no connection attempt yet (before clicking create/join)
- * `connected` — the server has acknowledged `create` or `join`
- * `failed`    — the WebSocket closed (either before ack, or after a previous
- *               successful connect)
+ * `idle`        — no connection attempt yet (before clicking create/join)
+ * `connected`   — the server has acknowledged `create` or `join`
+ * `failed`      — the WebSocket closed (either before ack, or after a previous
+ *                 successful connect)
+ * `maintenance` — the healthcheck endpoint returned an error (server may be
+ *                 down or under maintenance)
  */
-export type ConnectionStatus = "idle" | "connected" | "failed";
+export type ConnectionStatus = "idle" | "connected" | "failed" | "maintenance";

--- a/src/infrastructure/env.ts
+++ b/src/infrastructure/env.ts
@@ -19,6 +19,7 @@ export const BACKEND_PROTOCOL = IS_PRODUCTION ? "https://" : "http://";
 export const WEBSOCKET_PROTOCOL = IS_PRODUCTION ? "wss://" : "ws://";
 
 export const API_ENDPOINT = `${BACKEND_PROTOCOL}${BACKEND_HOST}api/v1/`;
+export const HEALTH_CHECK_ENDPOINT = `${API_ENDPOINT}health`;
 export const VERSION_CHECK_ENDPOINT = `${API_ENDPOINT}chrome-extension/version-check`;
 
 /**

--- a/src/presentation/content/party/react/mountSidebar.tsx
+++ b/src/presentation/content/party/react/mountSidebar.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 
+import { HEALTH_CHECK_ENDPOINT } from "@/infrastructure/env";
 import { PortalContainerContext } from "@/lib/portalContainer";
 
 import { Sidebar } from "./Sidebar";
@@ -110,5 +111,31 @@ export function mountSidebar(handlers: SidebarHandlers): MountedSidebar {
     </PortalContainerContext.Provider>,
   );
 
+  scheduleHealthCheck(store);
+
   return { store, controller };
+}
+
+/**
+ * サイドバーが初めて表示されたとき一度だけヘルスチェックを実行する。
+ * 失敗（ネットワークエラーまたは非 2xx）した場合はステータスを `"maintenance"` に
+ * 変更してメンテナンス中の黄色バッジを表示する。接続が成功すれば WS 側が
+ * `setConnectionStatus("connected")` を呼ぶため自動的に上書きされる。
+ */
+function scheduleHealthCheck(store: SidebarStore): void {
+  let done = false;
+  const unsubscribe = store.subscribe(() => {
+    if (done) return;
+    const { visible } = store.getSnapshot();
+    if (!visible) return;
+    done = true;
+    unsubscribe();
+    fetch(HEALTH_CHECK_ENDPOINT, { method: "GET" })
+      .then((res) => {
+        if (!res.ok) store.setConnectionStatus("maintenance");
+      })
+      .catch(() => {
+        store.setConnectionStatus("maintenance");
+      });
+  });
 }

--- a/src/presentation/content/party/react/sidebar/badges.tsx
+++ b/src/presentation/content/party/react/sidebar/badges.tsx
@@ -9,6 +9,7 @@ const CONNECTION_STATUS_META: Record<
   idle: { label: "接続前", dotClass: "bg-neutral-400" },
   connected: { label: "接続済み", dotClass: "bg-emerald-500" },
   failed: { label: "接続失敗", dotClass: "bg-red-500" },
+  maintenance: { label: "メンテナンス中", dotClass: "bg-yellow-400" },
 };
 
 export function ConnectionBadge({


### PR DESCRIPTION
## 変更内容

サイドバー初回表示時にバックエンドのヘルスチェックエンドポイント（`GET /api/v1/health`）を一度だけ叩く。

- 200 以外または通信エラー → `connectionStatus` を `"maintenance"` に設定
- `ConnectionBadge` が黄色ドット＋「メンテナンス中」ラベルを表示
- WebSocket 接続が成功すれば `"connected"` に自動上書きされる

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `domain/connectionStatus.ts` | `"maintenance"` 型を追加 |
| `infrastructure/env.ts` | `HEALTH_CHECK_ENDPOINT` 定数を追加 |
| `presentation/.../mountSidebar.tsx` | `scheduleHealthCheck()` を追加・呼び出し |
| `presentation/.../sidebar/badges.tsx` | `maintenance` を黄色バッジとして登録 |