### PR TITLE
fix(api): guard customFetch JSON.parse against non-JSON responses

### DIFF
--- a/src/infrastructure/api/fetcher.ts
+++ b/src/infrastructure/api/fetcher.ts
@@ -10,6 +10,16 @@ export const customFetch = async <T>(
 ): Promise<T> => {
   const response = await fetch(`${API_BASE_URL}${url}`, options);
   const body = await response.text();
-  const data = body ? JSON.parse(body) : undefined;
+  // Error responses from nginx/proxies (502/504 …) are often HTML, not JSON.
+  // Guard JSON.parse so a non-JSON body surfaces as `data: undefined` with the
+  // real status code instead of throwing an unhandled SyntaxError.
+  let data: unknown = undefined;
+  if (body) {
+    try {
+      data = JSON.parse(body);
+    } catch {
+      data = undefined;
+    }
+  }
   return { status: response.status, data, headers: response.headers } as T;
 };


### PR DESCRIPTION
## 概要

orval 生成 REST クライアントの `customFetch` を、非 JSON なエラーレスポンスに対して堅牢化する。

## 変更点

- `JSON.parse` を try/catch でガード。nginx 等のプロキシが返す 5xx は HTML 本文の
  ことが多く、現状は未捕捉の `SyntaxError` を投げていた。今後はパース失敗時に
  `data: undefined` と**実ステータスコード**を返す。
- フロントエンド側の `customFetch` と意図的に挙動を合わせている。

## 検証

- `pnpm typecheck`: パス
- `pnpm lint`: パス
