### PR TITLE
feat(sidebar): 操作タブの並び替えと退室ラベル変更

### DIFF
--- a/src/presentation/content/party/react/sidebar/panels.tsx
+++ b/src/presentation/content/party/react/sidebar/panels.tsx
@@ -156,28 +156,9 @@ export function ControlPanel({
 }): React.JSX.Element {
   return (
     <div className="flex flex-col gap-8 px-1 pb-3 pt-6">
-      {/* 入室後の詳細設定。オーナーのみ編集可能。非オーナーには現在値を read-only 表示。 */}
       <div className="flex flex-col gap-3">
-        <div className="flex items-center gap-1.5">
-          <p className="text-sm font-semibold">詳細設定</p>
-          {isOwner ? (
-            <OwnerBadge />
-          ) : (
-            <span className="text-[11px] text-muted-foreground">
-              （オーナーのみ変更可能）
-            </span>
-          )}
-        </div>
-        <RoomSettings
-          value={roomSettings}
-          onChange={onChangeRoomSettings}
-          disabled={!isOwner}
-        />
-      </div>
-
-      <div className="flex flex-col gap-3 border-t border-border pt-6">
         <div>
-          <p className="text-sm font-semibold">パーティールームから退室</p>
+          <p className="text-sm font-semibold">ルームから退室</p>
           <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
             退室するとサイドバーが閉じます。
           </p>
@@ -207,6 +188,25 @@ export function ControlPanel({
           <HoldToDeleteButton onConfirm={onDeleteRoom} />
         </div>
       )}
+
+      {/* 入室後の詳細設定。オーナーのみ編集可能。非オーナーには現在値を read-only 表示。 */}
+      <div className="flex flex-col gap-3 border-t border-border pt-6">
+        <div className="flex items-center gap-1.5">
+          <p className="text-sm font-semibold">詳細設定</p>
+          {isOwner ? (
+            <OwnerBadge />
+          ) : (
+            <span className="text-[11px] text-muted-foreground">
+              （オーナーのみ変更可能）
+            </span>
+          )}
+        </div>
+        <RoomSettings
+          value={roomSettings}
+          onChange={onChangeRoomSettings}
+          disabled={!isOwner}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

サイドバー操作タブのセクション順序を変更し、退室ラベルを改称する。

### 変更内容

- 並び順を変更: `詳細設定 → 退室 → ルーム削除` から **`退室 → ルーム削除 → 詳細設定`** へ
- 「パーティールームから退室」→ **「ルームから退室」** に改称
- 先頭になった退室セクションの `border-t` を外し、後続の削除・詳細設定セクションに付与（区切り線の整合）

機能・ハンドラ（`onLeave` / `onDeleteRoom` / `onChangeRoomSettings`）は不変。表示順とラベルのみの変更。

## 確認

- `pnpm typecheck` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)