### PR TITLE
feat(sidebar): ルーム詳細設定の変更を参加者へ通知

### DIFF
--- a/src/application/RoomSession.ts
+++ b/src/application/RoomSession.ts
@@ -4,6 +4,7 @@ import { isDefaultReaction } from "@/domain/reactions";
 import {
   type RoomSettings,
   DEFAULT_ROOM_SETTINGS,
+  diffRoomSettings,
   fromWire,
   isDefaultRoomSettings,
 } from "@/domain/roomSettings";
@@ -72,6 +73,10 @@ export class RoomSession {
   // サーバから通知された現在のルーム詳細設定。一方通行モードの動画操作抑止や
   // リアクション禁止の判定に使う。room_setting イベントで更新される。
   private roomSettings: RoomSettings = DEFAULT_ROOM_SETTINGS;
+  // create/join 直後にサーバが配る最初の room_setting は「現在値の初期同期」であり
+  // 設定変更ではない。これを有効化/無効化の通知と区別するため、最初の 1 通を受信済みか
+  // を持つ。以降の room_setting（オーナーが操作タブで変更したとき）だけ通知する。
+  private roomSettingsInitialized = false;
   // ルーム作成時に指定された初期設定。create 確定後に update_setting で適用する。
   private pendingSettings: RoomSettings | null = null;
   // 一方通行モードで非オーナーが操作を試みたときの「操作できません」通知を、
@@ -108,6 +113,7 @@ export class RoomSession {
     this._inRoom = true;
     this.joined = false;
     this.resetDelayMs = 100;
+    this.roomSettingsInitialized = false;
     this.pendingSettings = settings ?? null;
     this.deps.sidebar.setConnectionStatus("idle");
     this.openSocket(() => {
@@ -142,6 +148,7 @@ export class RoomSession {
     this._inRoom = true;
     this.joined = false;
     this.resetDelayMs = 200;
+    this.roomSettingsInitialized = false;
     this.roomId = roomId;
     this.deps.sidebar.setConnectionStatus("idle");
     this.openSocket(() => {
@@ -540,13 +547,22 @@ export class RoomSession {
           });
         }
         break;
-      case "room_setting":
+      case "room_setting": {
         // サーバから配布される現在のルーム詳細設定を反映する。一方通行モードの
         // 動画操作抑止やリアクション禁止の判定に使う。旧バックエンドは送らないため
         // 未受信なら既定値（すべて false）のままで現行挙動になる。
+        const previousSettings = this.roomSettings;
         this.roomSettings = fromWire(message);
         sidebar.setRoomSettings(this.roomSettings);
+        // 最初の 1 通は入室時の現在値同期なので通知しない。以降のオーナーによる変更
+        // だけを通知する。変更したオーナー本人（ホスト）は操作タブのトグルで把握できる
+        // ため、通知対象は非オーナーの参加者に限る。
+        if (this.roomSettingsInitialized && !this.isHost) {
+          this.notifyRoomSettingChanges(previousSettings, this.roomSettings);
+        }
+        this.roomSettingsInitialized = true;
         break;
+      }
     }
   }
 
@@ -586,6 +602,26 @@ export class RoomSession {
       user: userName,
       userIcon,
     });
+  }
+
+  // オーナーが操作タブで詳細設定を変更した（room_setting の差分がある）とき、
+  // 変化した設定ごとに「『◯◯』を有効化しました／無効化しました」をトースト＋履歴で
+  // ルーム内の参加者へ知らせる。
+  private notifyRoomSettingChanges(
+    previous: RoomSettings,
+    next: RoomSettings,
+  ): void {
+    for (const change of diffRoomSettings(previous, next)) {
+      const label = `『${change.label}』を${
+        change.enabled ? "有効化" : "無効化"
+      }しました`;
+      this.deps.notifier.info(label);
+      this.deps.sidebar.addHistory({
+        direction: "system",
+        icon: "info",
+        label,
+      });
+    }
   }
 
   // -- notifications ---------------------------------------------------------

--- a/src/domain/roomSettings.ts
+++ b/src/domain/roomSettings.ts
@@ -30,6 +30,47 @@ export function isDefaultRoomSettings(settings: RoomSettings): boolean {
   );
 }
 
+/**
+ * 各設定の表示名。オーナーが詳細設定を変更したとき、ルーム内の参加者へ出す
+ * 「『◯◯』を有効化しました」通知の `◯◯` に使う。
+ */
+export const ROOM_SETTING_LABELS: Record<keyof RoomSettings, string> = {
+  oneWay: "一方通行モード",
+  ownerLeaveDelete: "オーナー退室時の自動削除",
+  disableReaction: "リアクション禁止",
+};
+
+/** {@link diffRoomSettings} が返す、変化した 1 設定の内容。 */
+export interface RoomSettingChange {
+  key: keyof RoomSettings;
+  /** 表示名（{@link ROOM_SETTING_LABELS}）。 */
+  label: string;
+  /** 変更後の値。true なら有効化、false なら無効化。 */
+  enabled: boolean;
+}
+
+/**
+ * 2 つの設定を比較し、値が変化したフィールドだけを列挙する。`room_setting` 受信時に
+ * 「何が有効化/無効化されたか」の通知を組み立てるために使う。変化が無ければ空配列。
+ */
+export function diffRoomSettings(
+  previous: RoomSettings,
+  next: RoomSettings,
+): RoomSettingChange[] {
+  const keys: (keyof RoomSettings)[] = [
+    "oneWay",
+    "ownerLeaveDelete",
+    "disableReaction",
+  ];
+  return keys
+    .filter((key) => previous[key] !== next[key])
+    .map((key) => ({
+      key,
+      label: ROOM_SETTING_LABELS[key],
+      enabled: next[key],
+    }));
+}
+
 /** サーバ受信（snake_case）→ 内部表現。 */
 export function fromWire(wire: {
   one_way?: boolean;


### PR DESCRIPTION
## 概要

操作タブ（`ControlPanel`）でオーナーが詳細設定をトグルすると、`room_setting` ブロードキャストの差分を検出し、変更された設定ごとに『◯◯』を有効化しました／無効化しました をトースト＋サイドバー履歴でルーム内の参加者へ通知する。

## 変更点

- **`domain/roomSettings.ts`**
  - `ROOM_SETTING_LABELS`（各設定の表示名）を追加
  - `diffRoomSettings(previous, next)` … 値が変化したフィールドだけを列挙するユーティリティを追加
- **`application/RoomSession.ts`**
  - `room_setting` 受信時に前後を比較し、変更を `notifier.info` トースト＋履歴で通知
  - `notifyRoomSettingChanges` ヘルパーを追加

## 設計方針

- **入室時の初期同期は通知しない**: create/join 直後にサーバが配る最初の `room_setting`（現在値の同期）は `roomSettingsInitialized` フラグで除外し、以降の変更のみ通知する。
- **通知対象は非オーナーのみ**: 設定を変更できるのはオーナーだけで、本人は操作タブのトグルで把握できるため（`!isHost`）。これによりルーム作成時に初期設定を付けたオーナーへ余計な通知が出るのも防ぐ。

## 動作確認

- `pnpm typecheck` / `pnpm lint` / `pnpm build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)