### PR TITLE
fix(sidebar): proxy health check via background to avoid Local Network Access block

### DIFF
--- a/src/infrastructure/messages.ts
+++ b/src/infrastructure/messages.ts
@@ -1,0 +1,18 @@
+/**
+ * chrome.runtime メッセージの契約（content script ↔ background service worker）。
+ *
+ * Chrome の Local Network Access により、パブリックなページ（dアニメストア）に注入
+ * された content script から localhost への直接 fetch はユーザー許可が無いと弾かれる。
+ * host_permissions を持つ background service worker は LNA のページ許可ゲート対象外の
+ * ため、localhost を叩く必要のあるリクエストは background へ委譲する。
+ */
+
+/** サイドバーのヘルスチェック依頼。background が代理 fetch する。 */
+export interface HealthCheckRequest {
+  type: "healthCheck";
+}
+
+/** ヘルスチェックの結果。`ok` はレスポンスが 2xx だったか。 */
+export interface HealthCheckResponse {
+  ok: boolean;
+}

--- a/src/presentation/background/index.ts
+++ b/src/presentation/background/index.ts
@@ -5,7 +5,17 @@
  * flag in chrome.storage.local makes this idempotent so the page is never
  * reopened, even though onInstalled can fire more than once (reloading an
  * unpacked extension during development, browser/extension updates, etc.).
+ *
+ * Also proxies the sidebar health check: the content script cannot fetch
+ * localhost directly under Chrome's Local Network Access, so it delegates the
+ * probe here (see `src/infrastructure/messages.ts`).
  */
+import { HEALTH_CHECK_ENDPOINT } from "@/infrastructure/env";
+import type {
+  HealthCheckRequest,
+  HealthCheckResponse,
+} from "@/infrastructure/messages";
+
 const USAGE_OPENED_KEY = "usagePageOpened";
 const USAGE_URL = "https://d-party.net/usage";
 
@@ -20,3 +30,18 @@ async function openUsageOnce(): Promise<void> {
   await chrome.storage.local.set({ [USAGE_OPENED_KEY]: true });
   await chrome.tabs.create({ url: USAGE_URL });
 }
+
+chrome.runtime.onMessage.addListener(
+  (
+    message: HealthCheckRequest,
+    _sender,
+    sendResponse: (response: HealthCheckResponse) => void,
+  ) => {
+    if (message?.type !== "healthCheck") return undefined;
+    // background は host_permissions を持つため LNA に阻まれず localhost を叩ける。
+    fetch(HEALTH_CHECK_ENDPOINT, { method: "GET" })
+      .then((res) => sendResponse({ ok: res.ok }))
+      .catch(() => sendResponse({ ok: false }));
+    return true; // 非同期に sendResponse するためチャネルを開いたままにする。
+  },
+);

--- a/src/presentation/content/party/react/mountSidebar.tsx
+++ b/src/presentation/content/party/react/mountSidebar.tsx
@@ -1,7 +1,10 @@
 import { createRoot } from "react-dom/client";
 
 import type { RoomSettings } from "@/domain/roomSettings";
-import { HEALTH_CHECK_ENDPOINT } from "@/infrastructure/env";
+import type {
+  HealthCheckRequest,
+  HealthCheckResponse,
+} from "@/infrastructure/messages";
 import { PortalContainerContext } from "@/lib/portalContainer";
 
 import { Sidebar } from "./Sidebar";
@@ -129,6 +132,11 @@ export function mountSidebar(handlers: SidebarHandlers): MountedSidebar {
  * 失敗（ネットワークエラーまたは非 2xx）した場合はステータスを `"maintenance"` に
  * 変更してメンテナンス中の黄色バッジを表示する。接続が成功すれば WS 側が
  * `setConnectionStatus("connected")` を呼ぶため自動的に上書きされる。
+ *
+ * fetch は content script から直接行わず background service worker に委譲する。
+ * Chrome の Local Network Access により、パブリックなページ（dアニメストア）から
+ * localhost への直接 fetch はユーザー許可が無いと弾かれるため（host_permissions を
+ * 持つ background 経由なら LNA のページ許可ゲート対象外）。
  */
 function scheduleHealthCheck(store: SidebarStore): void {
   let done = false;
@@ -138,12 +146,11 @@ function scheduleHealthCheck(store: SidebarStore): void {
     if (!visible) return;
     done = true;
     unsubscribe();
-    fetch(HEALTH_CHECK_ENDPOINT, { method: "GET" })
-      .then((res) => {
-        if (!res.ok) store.setConnectionStatus("maintenance");
-      })
-      .catch(() => {
+    const request: HealthCheckRequest = { type: "healthCheck" };
+    chrome.runtime.sendMessage(request, (response?: HealthCheckResponse) => {
+      if (chrome.runtime.lastError || !response?.ok) {
         store.setConnectionStatus("maintenance");
-      });
+      }
+    });
   });
 }


### PR DESCRIPTION
## 概要

ローカル開発でサイドバーが常に「メンテナンス中」バッジになる不具合を修正する。

## 原因

サイドバー初回表示時のヘルスチェックを content script から `http://localhost/api/v1/health` へ直接 `fetch` していた。Chrome 138+（LNA: Local Network Access、旧 Private Network Access の後継）では、**パブリックなページ（dアニメストア）に注入された content script から localhost への直接リクエストはユーザー許可が無いとブロック**される。ブラウザがネットワークに出す前に弾くため、`.catch()` で `maintenance` に落ち、サイドバーが「メンテナンス中」になっていた。旧 PNA のサーバ応答ヘッダ（`Access-Control-Allow-Private-Network`）では解決できない（LNA はサーバヘッダではなくユーザー許可で制御）。

本番（`d-party.net`）はパブリック→パブリックで LNA 非対象のため発症しない。ローカル開発のみの症状。

## 修正

`host_permissions`（`http://localhost/*` を既に保持）を持つ **background service worker は LNA のページ許可ゲート対象外**なので、ヘルスチェックの `fetch` を background へ委譲する。

- `src/infrastructure/messages.ts`（新規）: content↔background のメッセージ契約（`healthCheck`）
- `src/presentation/background/index.ts`: `onMessage` で代理 `fetch` し `{ ok }` を返す
- `src/presentation/content/party/react/mountSidebar.tsx`: 直接 `fetch` を `chrome.runtime.sendMessage` に置換

## 影響

- 本番の挙動は不変（LNA 非対象、成功時は WS が `connected` へ上書き）。
- ローカル開発で「メンテナンス中」の誤検知が解消。

## テスト

- `pnpm typecheck` / `pnpm lint` / `pnpm build` 通過。
- 手動確認: 拡張リロード後、dアニメストアのプレイヤーページでサイドバー表示 → nginx access log に `GET /api/v1/health 200` が届き、バッジがメンテナンス中でなくなること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)